### PR TITLE
update license test by removing duplicate test file

### DIFF
--- a/pkg/license/license_unit_test.go
+++ b/pkg/license/license_unit_test.go
@@ -71,7 +71,7 @@ func TestCacheData(t *testing.T) {
 
 func TestFindLicenseFiles(t *testing.T) {
 	files := []string{
-		"LICENSE", "LICENSE.txt", "LICENSE-APACHE2", "APACHE2-LICENSE", "license",
+		"LICENSE", "LICENSE.txt", "LICENSE-APACHE2", "APACHE2-LICENSE",
 		"license.go", "README.md",
 	}
 
@@ -80,7 +80,7 @@ func TestFindLicenseFiles(t *testing.T) {
 	defer func() { require.Nil(t, os.RemoveAll(tempdir)) }()
 
 	require.Nil(t, os.MkdirAll(filepath.Join(tempdir, "/some/sub/dir"), os.FileMode(0o755)))
-	fileData := []byte("bleh")
+	fileData := []byte("some license")
 	for _, sub := range []string{"", "/some/sub/dir"} {
 		for _, filename := range files {
 			require.Nil(t, os.WriteFile(
@@ -92,7 +92,7 @@ func TestFindLicenseFiles(t *testing.T) {
 	impl := ReaderDefaultImpl{}
 	res, err := impl.FindLicenseFiles(tempdir)
 	require.Nil(t, err)
-	require.Equal(t, 10, len(res), fmt.Sprintf("%+v", res))
+	require.Equal(t, 8, len(res), fmt.Sprintf("%+v", res))
 	require.NotContains(t, res, filepath.Join(tempdir, "license.go"))
 	require.NotContains(t, res, filepath.Join(tempdir, "README.md"))
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
- update license test by removing duplicate test file

windows and mac do see files with the same name but different caps all the same like LICENSE and license are the same file then the tests will fail for those platforms, skipping the tests if that run on mac/windows

/assign @puerco @xmudrii @Verolop 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
