### PR TITLE
Fix flake in TestToProvenance and TestWriteProvenance

### DIFF
--- a/pkg/spdx/document_unit_test.go
+++ b/pkg/spdx/document_unit_test.go
@@ -1,6 +1,7 @@
 package spdx
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/bom/pkg/provenance"
-	"sigs.k8s.io/release-utils/hash"
 )
 
 func generateProvenanceSUT(t *testing.T) (doc *Document, tmpDir string) {
@@ -36,8 +36,9 @@ func generateProvenanceSUT(t *testing.T) (doc *Document, tmpDir string) {
 	return doc, tmpDir
 }
 
-func TestToProvenance(t *testing.T) {
-	// Create a statement with the known digests
+// testStatement returns a predictable statement that we can use to
+// compare generating functions
+func testStatement() *provenance.Statement {
 	statement := provenance.NewSLSAStatement()
 	statement.Subject = append(statement.Subject,
 		in_toto.Subject{
@@ -65,16 +66,47 @@ func TestToProvenance(t *testing.T) {
 			},
 		},
 	)
+	return statement
+}
 
+func TestToProvenance(t *testing.T) {
 	// Create a second statement by writing known files
 	doc, tmpDir := generateProvenanceSUT(t)
 	defer os.RemoveAll(tmpDir)
 
-	statement2 := doc.ToProvenanceStatement(DefaultProvenanceOptions)
+	statement := doc.ToProvenanceStatement(DefaultProvenanceOptions)
+	compareSubjects(t, testStatement(), statement)
+}
 
+func TestWriteProvenance(t *testing.T) {
+	doc, tmpDir := generateProvenanceSUT(t)
+	defer os.RemoveAll(tmpDir)
+
+	tfile, err := os.CreateTemp("", "test-provenance-*.json")
+	require.NoError(t, err)
+	defer os.Remove(tfile.Name())
+
+	// Write the provenance to a file
+	require.NoError(t, doc.WriteProvenanceStatement(DefaultProvenanceOptions, tfile.Name()))
+	require.NoError(t, err)
+
+	// Now, read it back and compare to what we know
+	data, err := os.ReadFile(tfile.Name())
+	require.NoError(t, err)
+	statement1 := &provenance.Statement{}
+	require.NoError(t, json.Unmarshal(data, statement1))
+
+	compareSubjects(t, statement1, testStatement())
+}
+
+// This function gets two provenance statements and checks their
+// subjects to be equivalent, returning an error if they do not match
+func compareSubjects(t *testing.T, statement1, statement2 *provenance.Statement) {
+	require.Equal(t, len(statement1.Subject), len(statement2.Subject))
 	// Compare the statements manually to ensure they are equivalent
-	for _, s1 := range statement.Subject {
+	for _, s1 := range statement1.Subject {
 		for _, s2 := range statement2.Subject {
+			require.Equal(t, len(s1.Digest), len(s2.Digest))
 			if s1.Name == s2.Name {
 				for _, algo := range []string{"sha1", "sha256", "sha512"} {
 					require.Equal(
@@ -84,18 +116,4 @@ func TestToProvenance(t *testing.T) {
 			}
 		}
 	}
-}
-
-func TestWriteProvenance(t *testing.T) {
-	doc, tmpDir := generateProvenanceSUT(t)
-	defer os.RemoveAll(tmpDir)
-
-	tfile, err := os.CreateTemp(tmpDir, "test-provenance-*.json")
-	require.NoError(t, err)
-	defer os.Remove(tfile.Name())
-	// Write the peovenance
-	require.NoError(t, doc.WriteProvenanceStatement(DefaultProvenanceOptions, tfile.Name()))
-	s512, err := hash.SHA512ForFile(tfile.Name())
-	require.NoError(t, err)
-	require.Equal(t, "d877604a3f1abe9f339ce3de3ebde227f0d9626972387f62ee00951bd83bab12a59bbec3b440a0e74aab60263f4b1f80e8268e922d2dcf760980ed006149bf97", s512)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/kind flake

#### What this PR does / why we need it:

The `TestToProvenance` test was flaking because the order of the provenance subjects was unpredictable causing `require.Equal` to fail to match the SUT against the known example.

The same flake was happening in `TestWriteProvenance`. So a second commit introduces a function to compare
provenance Subjects that both tests share.

This change modifies the check to compare the Subject hashes one by one and avoid the 1/3 chance that the test would flake.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>


#### Which issue(s) this PR fixes:
Related to flakes in https://github.com/kubernetes-sigs/bom/pull/24 and https://github.com/kubernetes-sigs/bom/pull/18


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed flakes in `TestWriteProvenance` and `TestToProvenance` where the test would fail one every three runs
```
