### PR TITLE
go imports update and fix mage build command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
-	github.com/magefile/mage v1.12.1 // indirect
+	github.com/magefile/mage v1.12.1
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect

--- a/magefile.go
+++ b/magefile.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/carolynvs/magex/pkg"
+	"github.com/magefile/mage/sh"
 
 	"sigs.k8s.io/release-utils/mage"
 )
@@ -91,10 +92,31 @@ func Verify() error {
 		return err
 	}
 
+	if err := Build(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Build runs go build
+func Build() error {
 	fmt.Println("Running go build...")
 	if err := mage.VerifyBuild(scriptDir); err != nil {
 		return err
 	}
 
+	fmt.Println("Binaries available in the output directory.")
 	return nil
+}
+
+func Clean() {
+	fmt.Println("Cleaning workspace...")
+	toClean := []string{"output"}
+
+	for _, clean := range toClean {
+		sh.Rm(clean)
+	}
+
+	fmt.Println("Done.")
 }

--- a/pkg/license/catalog.go
+++ b/pkg/license/catalog.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/release-utils/util"
 )
 

--- a/pkg/license/download.go
+++ b/pkg/license/download.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nozzle/throttler"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/release-utils/http"
 	"sigs.k8s.io/release-utils/util"
 )

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/release-utils/util"
 )
 

--- a/pkg/provenance/statement.go
+++ b/pkg/provenance/statement.go
@@ -28,12 +28,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"sigs.k8s.io/release-utils/hash"
-
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/release-utils/hash"
 )
 
 // Statement is the middle layer of the attestation, binding it to a particular subject and

--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
+
 	"sigs.k8s.io/release-utils/util"
 )
 

--- a/pkg/spdx/document_unit_test.go
+++ b/pkg/spdx/document_unit_test.go
@@ -11,6 +11,7 @@ import (
 	v02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+
 	"sigs.k8s.io/bom/pkg/provenance"
 )
 

--- a/pkg/spdx/imageanalyzer.go
+++ b/pkg/spdx/imageanalyzer.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/spdx/object.go
+++ b/pkg/spdx/object.go
@@ -31,6 +31,7 @@ import (
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/release-utils/hash"
 	"sigs.k8s.io/release-utils/util"
 )

--- a/pkg/spdx/spdx_unit_test.go
+++ b/pkg/spdx/spdx_unit_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"sigs.k8s.io/release-utils/util"
 )
 

--- a/scripts/verify-build.sh
+++ b/scripts/verify-build.sh
@@ -30,6 +30,12 @@ for PLATFORM in "${PLATFORMS[@]}"; do
     OS="${PLATFORM%/*}"
     ARCH=$(basename "$PLATFORM")
 
+    output_name=bom'-'$OS'-'$ARCH
+
+    if [ "$OS" = "windows" ]; then
+        output_name+='.exe'
+    fi
+
     echo "Building project for $PLATFORM"
-    GOARCH="$ARCH" GOOS="$OS" go build ./...
+    GOARCH="$ARCH" GOOS="$OS" go build -o output/$output_name ./cmd/bom/main.go
 done


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature


#### What this PR does / why we need it:
- general go import updates to organize it
- fix the build command to build the `bom` binaries 
- add clean mage command 


now can use

```shell
$ mage build
Running go build...
Building project for linux/amd64
Building project for linux/arm64
Building project for darwin/amd64
Building project for darwin/arm64
Building project for windows/amd64
Binaries available in the output directory.

$ ./output/bom-darwin-amd64 --help
bom (Bill of Materials)
....
```

/assing @puerco @justaugustus @saschagrunert 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
