### PR TITLE
add version command and ldflags

### DIFF
--- a/cmd/bom/cmd/root.go
+++ b/cmd/bom/cmd/root.go
@@ -61,6 +61,7 @@ func init() {
 
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(documentCmd)
+	rootCmd.AddCommand(versionCmd)
 }
 
 // Execute builds the command

--- a/cmd/bom/cmd/version.go
+++ b/cmd/bom/cmd/version.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/bom/pkg/version"
+)
+
+var versionOpts = &versionOptions{}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Prints the version of the bom tool",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		v := version.GetVersionInfo()
+		res := v.String()
+		if versionOpts.outputJSON {
+			j, err := v.JSONString()
+			if err != nil {
+				return errors.Wrap(err, "unable to generate JSON from version info")
+			}
+			res = j
+		}
+
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	versionCmd.Flags().BoolVar(&versionOpts.outputJSON, "json", false,
+		"print JSON instead of text")
+}
+
+type versionOptions struct {
+	outputJSON bool
+}

--- a/magefile.go
+++ b/magefile.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/carolynvs/magex/pkg"
@@ -102,6 +103,9 @@ func Verify() error {
 // Build runs go build
 func Build() error {
 	fmt.Println("Running go build...")
+
+	os.Setenv("BOM_LDFLAGS", generateLDFlags())
+
 	if err := mage.VerifyBuild(scriptDir); err != nil {
 		return err
 	}
@@ -119,4 +123,49 @@ func Clean() {
 	}
 
 	fmt.Println("Done.")
+}
+
+// getVersion gets a description of the commit, e.g. v0.30.1 (latest) or v0.30.1-32-gfe72ff73 (canary)
+func getVersion() string {
+	version, _ := sh.Output("git", "describe", "--tags", "--match=v*")
+	if version != "" {
+		return version
+	}
+
+	// repo without any tags in it
+	return "v0.0.0"
+}
+
+// getCommit gets the hash of the current commit
+func getCommit() string {
+	commit, _ := sh.Output("git", "rev-parse", "--short", "HEAD")
+	return commit
+}
+
+// getGitState gets the state of the git repository
+func getGitState() string {
+	_, err := sh.Output("git", "diff", "--quiet")
+	if err != nil {
+		return "dirty"
+	}
+
+	return "clean"
+}
+
+// getBuildDateTime gets the build date and time
+func getBuildDateTime() string {
+	result, _ := sh.Output("git", "log", "-1", "--pretty=%ct")
+	if result != "" {
+		sourceDateEpoch := fmt.Sprintf("@%s", result)
+		date, _ := sh.Output("date", "-u", "-d", sourceDateEpoch, "+%Y-%m-%dT%H:%M:%SZ")
+		return date
+	}
+
+	date, _ := sh.Output("date", "+%Y-%m-%dT%H:%M:%SZ")
+	return date
+}
+
+func generateLDFlags() string {
+	pkg := "sigs.k8s.io/bom/pkg/version"
+	return fmt.Sprintf("-X %[1]s.GitVersion=%[2]s -X %[1]s.gitCommit=%[3]s -X %[1]s.gitTreeState=%[4]s -X %[1]s.buildDate=%[5]s", pkg, getVersion(), getCommit(), getGitState(), getBuildDateTime())
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"strings"
+	"text/tabwriter"
+)
+
+// Base version information.
+//
+// This is the fallback data used when version information from git is not
+// provided via go ldflags (e.g. via Makefile).
+var (
+	// Output of "git describe". The prerequisite is that the branch should be
+	// tagged using the correct versioning strategy.
+	GitVersion = "devel"
+	// SHA1 from git, output of $(git rev-parse HEAD)
+	gitCommit = "unknown"
+	// State of git tree, either "clean" or "dirty"
+	gitTreeState = "unknown"
+	// Build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildDate = "unknown"
+)
+
+type Info struct {
+	GitVersion   string
+	GitCommit    string
+	GitTreeState string
+	BuildDate    string
+	GoVersion    string
+	Compiler     string
+	Platform     string
+}
+
+func GetVersionInfo() Info {
+	return Info{
+		GitVersion:   GitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+// String returns the string representation of the version info
+func (i *Info) String() string {
+	b := strings.Builder{}
+	w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+
+	fmt.Fprint(w, `______  ________  ___
+| ___ \|  _  |  \/  |
+| |_/ /| | | | .  . |
+| ___ \| | | | |\/| |
+| |_/ /\ \_/ / |  | |
+\____/  \___/\_|  |_/
+`)
+	fmt.Fprint(w, "bom: A tool for working with SPDX manifests\n\n")
+	fmt.Fprintf(w, "GitVersion:\t%s\n", i.GitVersion)
+	fmt.Fprintf(w, "GitCommit:\t%s\n", i.GitCommit)
+	fmt.Fprintf(w, "GitTreeState:\t%s\n", i.GitTreeState)
+	fmt.Fprintf(w, "BuildDate:\t%s\n", i.BuildDate)
+	fmt.Fprintf(w, "GoVersion:\t%s\n", i.GoVersion)
+	fmt.Fprintf(w, "Compiler:\t%s\n", i.Compiler)
+	fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
+
+	w.Flush()
+	return b.String()
+}
+
+// JSONString returns the JSON representation of the version info
+func (i *Info) JSONString() (string, error) {
+	b, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionText(t *testing.T) {
+	sut := GetVersionInfo()
+	require.NotEmpty(t, sut.String())
+}
+
+func TestVersionJSON(t *testing.T) {
+	sut := GetVersionInfo()
+	json, err := sut.JSONString()
+
+	require.Nil(t, err)
+	require.NotEmpty(t, json)
+}

--- a/scripts/verify-build.sh
+++ b/scripts/verify-build.sh
@@ -37,5 +37,5 @@ for PLATFORM in "${PLATFORMS[@]}"; do
     fi
 
     echo "Building project for $PLATFORM"
-    GOARCH="$ARCH" GOOS="$OS" go build -o output/$output_name ./cmd/bom/main.go
+    GOARCH="$ARCH" GOOS="$OS" go build -trimpath -ldflags "${BOM_LDFLAGS}" -o output/$output_name ./cmd/bom/main.go
 done


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
- add version command and ldflags

to help in debug and inform the user which version they are using

```
$ ./output/bom-darwin-amd64 version
______  ________  ___
| ___ \|  _  |  \/  |
| |_/ /| | | | .  . |
| ___ \| | | | |\/| |
| |_/ /\ \_/ / |  | |
\____/  \___/\_|  |_/
bom: A tool for working with SPDX manifests

GitVersion:    v0.1.0-64-ga8d39d8
GitCommit:     a8d39d8
GitTreeState:  dirty
BuildDate:     2022-01-22T17:25:52Z
GoVersion:     go1.17.6
Compiler:      gc
Platform:      darwin/amd64
```


/assign @puerco @justaugustus @xmudrii @Verolop @saschagrunert 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
