### PR TITLE
generate: Add --name --scan-images and check files early

### DIFF
--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -79,6 +79,7 @@ type generateOptions struct {
 	noGitignore    bool
 	noGoModules    bool
 	noGoTransient  bool
+	scanImages     bool
 	namespace      string
 	outputFile     string
 	configFile     string
@@ -233,6 +234,13 @@ func init() {
 		"",
 		"path to export the SBOM as an in-toto provenance statement",
 	)
+
+	generateCmd.PersistentFlags().BoolVar(
+		&genOpts.scanImages,
+		"scan-images",
+		true,
+		"scan container images to look for OS information (currently just debian is supported)",
+	)
 }
 
 func generateBOM(opts *generateOptions) error {
@@ -255,6 +263,7 @@ func generateBOM(opts *generateOptions) error {
 		OnlyDirectDeps:   !opts.noGoTransient,
 		ConfigFile:       opts.configFile,
 		License:          opts.license,
+		ScanImages:       opts.scanImages,
 	}
 
 	// We only replace the ignore patterns one or more where defined

--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -273,6 +273,15 @@ func init() {
 		"",
 		"name for the document, in contrast to URLs, intended for humans",
 	)
+
+	if err := generateCmd.MarkPersistentFlagDirname("dirs"); err != nil {
+		logrus.Error("error marking flag as directory")
+	}
+	for _, fl := range []string{"config", "image-archive", "file", "archive"} {
+		if err := generateCmd.MarkPersistentFlagFilename(fl); err != nil {
+			logrus.Error("error marking flag as file")
+		}
+	}
 }
 
 func generateBOM(opts *generateOptions) error {

--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -80,6 +80,7 @@ type generateOptions struct {
 	noGoModules    bool
 	noGoTransient  bool
 	scanImages     bool
+	name           string // Name to use in the document
 	namespace      string
 	outputFile     string
 	configFile     string
@@ -239,7 +240,14 @@ func init() {
 		&genOpts.scanImages,
 		"scan-images",
 		true,
-		"scan container images to look for OS information (currently just debian is supported)",
+		"scan container images to look for OS information (currently debian only)",
+	)
+
+	generateCmd.PersistentFlags().StringVar(
+		&genOpts.name,
+		"name",
+		"",
+		"name for the document, in contrast to URLs, intended for humans",
 	)
 }
 
@@ -264,6 +272,7 @@ func generateBOM(opts *generateOptions) error {
 		ConfigFile:       opts.configFile,
 		License:          opts.license,
 		ScanImages:       opts.scanImages,
+		Name:             opts.name,
 	}
 
 	// We only replace the ignore patterns one or more where defined

--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -92,6 +92,7 @@ type DocGenerateOptions struct {
 	ProcessGoModules    bool                  // Analyze go.mod to include data about packages
 	OnlyDirectDeps      bool                  // Only include direct dependencies from go.mod
 	ScanLicenses        bool                  // Try to look into files to determine their license
+	ScanImages          bool                  // When true, scan images for OS information
 	ConfigFile          string                // Path to SBOM configuration file
 	OutputFile          string                // Output location
 	Name                string                // Name to use in the resulting document

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -684,13 +684,19 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 
 	// Scan the container layers for OS information:
 	ct := osinfo.ContainerScanner{}
+	var osPackageData *[]osinfo.PackageDBEntry
+	var layerNum int
 	layerPaths := []string{}
 	for _, layerFile := range manifest.LayerFiles {
 		layerPaths = append(layerPaths, filepath.Join(tarOpts.ExtractDir, layerFile))
 	}
-	layerNum, osPackageData, err := ct.ReadOSPackages(layerPaths)
-	if err != nil {
-		return nil, errors.Wrap(err, "getting os data from container")
+
+	// Scan for package data if option is set
+	if spdxOpts.ScanImages {
+		layerNum, osPackageData, err = ct.ReadOSPackages(layerPaths)
+		if err != nil {
+			return nil, errors.Wrap(err, "getting os data from container")
+		}
 	}
 
 	if osPackageData != nil {

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -75,6 +75,7 @@ type Options struct {
 	OnlyDirectDeps   bool     // Only include direct dependencies from go.mod
 	ScanLicenses     bool     // Scan licenses from everypossible place unless false
 	AddTarFiles      bool     // Scan and add files inside of tarfiles
+	ScanImages       bool     // When true, scan container images for OS information
 	LicenseCacheDir  string   // Directory to cache SPDX license downloads
 	LicenseData      string   // Directory to store the SPDX licenses
 	IgnorePatterns   []string // Patterns to ignore when scanning file
@@ -91,6 +92,7 @@ var defaultSPDXOptions = Options{
 	ProcessGoModules: true,
 	IgnorePatterns:   []string{},
 	ScanLicenses:     true,
+	ScanImages:       true,
 }
 
 type ArchiveManifest struct {


### PR DESCRIPTION
#### What type of PR is this?


/kind bug
/kind cleanup
/kind feature


#### What this PR does / why we need it:

This PR has 3 parts:

1. Adds a new flag `--name` to allow the user to specify the name used in the document, if left blank it gets autogenerated
2. Adds a new flag `--scan-images` that determine if images are scanned for OS information
3. Introduces a new check where all arguments that take files and directories as arguments will be checked for existence before starting to generate the SBOM.

Thanks @kfaseela for sharing your use case!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?

```release-note
- Files and directories passed in flags to the bom utility are now checked for existence before running the SBOM generator
- New flag `--name` allows thew user to set the document name from the command line
- New flag `--scan-images` controls if container images are scanned for OS packages or not
```
