### PR TITLE
Autodetect compressed tarballs and fix --scan-images flag

### DIFF
--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -162,6 +162,7 @@ func (builder *defaultDocBuilderImpl) GenerateDoc(
 	}
 	spdx.Options().AnalyzeLayers = genopts.AnalyseLayers
 	spdx.Options().ProcessGoModules = genopts.ProcessGoModules
+	spdx.Options().ScanImages = genopts.ScanImages
 
 	if !util.Exists(opts.WorkDir) {
 		if err := os.MkdirAll(opts.WorkDir, os.FileMode(0o755)); err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR fixes two bugs:

1. Compressed tarballs are now autodetected and correctly handled by checking the first bytes in the header.  
2. There was a missing bit in the new --scan-images flag that missed some plumbing. Fixed now.

#### Which issue(s) this PR fixes:

Fixes #36


#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?

```release-note
- Tarball headers are now checked to see if they are compressed. Previously we relied on file extensions which made the tarball handling code flaky
- Fixed a proble where `--scan-images` was unresponsive because a bug in the internal plumbing 
```
