### PR TITLE
Validate Subcommand!

### DIFF
--- a/cmd/bom/cmd/root.go
+++ b/cmd/bom/cmd/root.go
@@ -62,6 +62,7 @@ func init() {
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(documentCmd)
 	rootCmd.AddCommand(versionCmd)
+	AddValidate(rootCmd)
 }
 
 // Execute builds the command

--- a/cmd/bom/cmd/validate.go
+++ b/cmd/bom/cmd/validate.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/bom/pkg/spdx"
+	"sigs.k8s.io/release-utils/util"
+)
+
+func AddValidate(parent *cobra.Command) {
+	valOpts := validateOptions{
+		files: []string{},
+	}
+
+	cmd := &cobra.Command{
+		Short: "bom validate → Check artifacts against an sbom",
+		Long: `bom validate → Check artifacts against an sbom
+
+validate is the bom subcommand to check artifacts against SPDX
+manifests.
+
+This is an experimental command. The first iteration has support
+for checking files.
+
+`,
+		Use:               "validate",
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+		PersistentPreRunE: initLogging,
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for i, arg := range args {
+				if util.Exists(arg) {
+					file, err := os.Open(arg)
+					if err != nil {
+						return errors.Wrapf(err, "checking argument %d", i)
+					}
+					defer file.Close()
+					fileInfo, err := file.Stat()
+					if err != nil {
+						return errors.Wrapf(err, "calling stat on argument %d", i)
+					}
+					if fileInfo.IsDir() {
+						return errors.Errorf(
+							"the path %s is a directory, only files are supported at this time",
+							file.Name(),
+						)
+					}
+					if i == 0 {
+						valOpts.sbomPath = arg
+					} else {
+						valOpts.files = append(valOpts.files, file.Name())
+					}
+				} else {
+					return errors.Errorf("the path specified at %s does not exist", arg)
+				}
+			}
+			return validateArtifacts(valOpts)
+		},
+	}
+
+	cmd.PersistentFlags().StringSliceVarP(
+		&valOpts.files,
+		"files",
+		"f",
+		[]string{},
+		"list of files to verify",
+	)
+
+	cmd.PersistentFlags().BoolVarP(
+		&valOpts.exitCode,
+		"exit-code",
+		"e",
+		false,
+		"when true, bom will exit with exit code 1 if invalid artifacts are found",
+	)
+
+	parent.AddCommand(cmd)
+}
+
+type validateOptions struct {
+	exitCode bool
+	sbomPath string
+	files    []string
+}
+
+// Validate verify options consistency
+func (opts *validateOptions) Validate() error {
+	if len(opts.files) == 0 {
+		return errors.New("please provide at least one artifact to validate")
+	}
+
+	return nil
+}
+
+func validateArtifacts(opts validateOptions) error {
+	if err := opts.Validate(); err != nil {
+		return errors.Wrap(err, "validating command line options")
+	}
+
+	if !opts.exitCode {
+		logrus.Info("Checking files against SPDX Bill of Materials")
+	}
+	doc, err := spdx.OpenDoc(opts.sbomPath)
+	if err != nil {
+		return errors.Wrap(err, "opening doc")
+	}
+
+	res, err := doc.ValidateFiles(opts.files)
+	if err != nil {
+		return errors.Wrap(err, "validating files")
+	}
+
+	data := [][]string{}
+	for _, res := range res {
+		// If we only want an exit code abort on the first failure
+		if !res.Success && opts.exitCode {
+			logrus.Errorf("Checking %s: %s", res.FileName, res.Message)
+			os.Exit(1)
+		}
+		resRow := []string{
+			res.FileName,
+			"FAIL",
+			res.Message,
+			"-",
+		}
+		if res.Message == spdx.MessageHashMismatch && len(res.FailedAlgorithms) > 0 {
+			resRow[3] = strings.Join(res.FailedAlgorithms, " ")
+		}
+		if res.Success {
+			resRow[1] = "OK"
+		}
+		data = append(data, resRow)
+	}
+
+	// Exit now if we only want the exit code
+	if opts.exitCode {
+		logrus.Info("All files valid")
+		os.Exit(0)
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"FileName", "Valid", "Message", "Invalid Hashes"})
+
+	for _, v := range data {
+		table.Append(v)
+	}
+	table.Render()
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,10 @@ require (
 	sigs.k8s.io/release-utils v0.4.0
 )
 
-require github.com/mitchellh/go-homedir v1.1.0 // indirect
+require (
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+)
 
 require (
 	github.com/acomagu/bufpipe v1.0.3 // indirect
@@ -39,6 +42,7 @@ require (
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/magefile/mage v1.12.1
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -592,6 +592,8 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
@@ -642,6 +644,8 @@ github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWk
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -49,8 +49,11 @@ LyBfYCBcIFwvIC8KXF9fIFwgfF8pIHwgKF98IHw+ICA8IAp8X19fLyAuX18vIFxfXyxfL18vXF9c
 CiAgICB8X3wgICAgICAgICAgICAgICAK`
 )
 
-// https://spdx.github.io/spdx-spec/3-package-information/#32-package-spdx-identifier
-var validIDCharsRe = regexp.MustCompile(`[^a-zA-Z0-9-.]+`)
+var (
+	// https://spdx.github.io/spdx-spec/3-package-information/#32-package-spdx-identifier
+	validIDCharsRe          = regexp.MustCompile(`[^a-zA-Z0-9-.]+`)
+	SupportedHashAlgorithms = []string{"SHA1", "SHA256", "SHA25"}
+)
 
 type SPDX struct {
 	impl    spdxImplementation


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR introduces to bom the capability to start validating things. For now, only files attached to the first level of the document are supported and we will be introducing more artifact types and other kinds of validation.

![image](https://user-images.githubusercontent.com/3935899/151669805-ea29a8d5-bf0d-44cc-9037-c6bf76616c1c.png)


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

~~Test for `document.ValidateFiles()` is coming in a followup shortly~~

Test is now included

/assign @cpanato 

#### Does this PR introduce a user-facing change?

```release-note
`bom` can now validate artifacts! We now have a new validate subcommand that can be used to check files attached to the top of the SBOM: `bom validate sbom.spdx file.txt`. No more checksum.txt files! 🎉
```
