### PR TITLE
Disable cgo in build script

### DIFF
--- a/scripts/verify-build.sh
+++ b/scripts/verify-build.sh
@@ -37,5 +37,5 @@ for PLATFORM in "${PLATFORMS[@]}"; do
     fi
 
     echo "Building project for $PLATFORM"
-    GOARCH="$ARCH" GOOS="$OS" go build -trimpath -ldflags "${BOM_LDFLAGS}" -o output/$output_name ./cmd/bom/main.go
+    CGO_ENABLED=0 GOARCH="$ARCH" GOOS="$OS" go build -trimpath -ldflags "${BOM_LDFLAGS}" -o output/$output_name ./cmd/bom/main.go
 done


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

The build script called by the magefile was producing dynamic executables. 

This commit disables cgo to produce static binaries.

Signed-off-by: Adolfo García Veytia <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/assign @cpanato 

#### Does this PR introduce a user-facing change?
```release-note
released `bom` binaries are now statically compiled
```
