### PR TITLE
builder: Support archives in config

### DIFF
--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -304,6 +304,8 @@ func (builder *defaultDocBuilderImpl) ReadYamlConfiguration(
 			opts.Tarballs = append(opts.Tarballs, artifact.Source)
 		case "file":
 			opts.Files = append(opts.Files, artifact.Source)
+		case "archive":
+			opts.Archives = append(opts.Archives, artifact.Source)
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This commit adds support for adding archives to the SBOM from
the YAML configuration file. All other artifacts were already
supported but archives are a newer kind and had not been added yet.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

Sample configuration:

```yaml
---
namespace: https://example.com/
license: Apache-2.0
name: myproject
artifacts:
    - type: archive
      source: file.tar
```

#### Does this PR introduce a user-facing change?

```release-note
The YAML configuration file now supports adding archives using `type: archive`
```
