### PR TITLE
generate: Print bom version when running

### DIFF
--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/bom/pkg/spdx"
+	"sigs.k8s.io/bom/pkg/version"
 	"sigs.k8s.io/release-utils/util"
 )
 
@@ -285,7 +286,10 @@ func init() {
 }
 
 func generateBOM(opts *generateOptions) error {
-	logrus.Info("Generating SPDX Bill of Materials")
+	logrus.Infof(
+		"bom %s: Generating SPDX Bill of Materials",
+		version.GetVersionInfo().GitVersion,
+	)
 
 	builder := spdx.NewDocBuilder()
 	builderOpts := &spdx.DocGenerateOptions{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It helps a lot to debug when generating an SBOM if you know
the bom version you are running. This change modifies the
first log output so that it gets written to the CI/CD log:

```
  bom VERSION: Generating SPDX Bill of Materials
```

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:


None

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
```release-note
When generating an SBOM, `bom` will now print its version before running to record it in CI/CD logs
```
