### PR TITLE
add flag to set a work directory

### DIFF
--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -92,6 +92,7 @@ type generateOptions struct {
 	configFile     string
 	license        string
 	provenancePath string // Path to export the SBOM as provenance statement
+	workDir        string
 	images         []string
 	imageArchives  []string
 	archives       []string
@@ -129,6 +130,13 @@ func (opts *generateOptions) Validate() error {
 			}
 		}
 	}
+
+	if opts.workDir != "" {
+		if _, err := os.Stat(opts.workDir); os.IsNotExist(err) {
+			return errors.Errorf("directory %s not found", opts.workDir)
+		}
+	}
+
 	return nil
 }
 
@@ -147,6 +155,14 @@ func init() {
 		"f",
 		[]string{},
 		"list of files to include",
+	)
+
+	generateCmd.PersistentFlags().StringVarP(
+		&genOpts.workDir,
+		"workDir",
+		"C",
+		"",
+		"Base working directory",
 	)
 
 	generateCmd.PersistentFlags().StringSliceVarP(
@@ -303,6 +319,7 @@ func generateBOM(opts *generateOptions) error {
 		License:          opts.license,
 		ScanImages:       opts.scanImages,
 		Name:             opts.name,
+		WorkDir:          opts.workDir,
 	}
 
 	// We only replace the ignore patterns one or more where defined

--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -69,6 +69,7 @@ func (db *DocBuilder) Generate(genopts *DocGenerateOptions) (*Document, error) {
 			return nil, errors.Wrap(err, "parsing configuration file")
 		}
 	}
+
 	// Create the SPDX document
 	doc, err := db.impl.GenerateDoc(db.options, genopts)
 	if err != nil {
@@ -87,18 +88,19 @@ func (db *DocBuilder) Generate(genopts *DocGenerateOptions) (*Document, error) {
 }
 
 type DocGenerateOptions struct {
-	AnalyseLayers       bool                  // A flag that controls if deep layer analysis should be performed
-	NoGitignore         bool                  // Do not read exclusions from gitignore file
-	ProcessGoModules    bool                  // Analyze go.mod to include data about packages
-	OnlyDirectDeps      bool                  // Only include direct dependencies from go.mod
-	ScanLicenses        bool                  // Try to look into files to determine their license
-	ScanImages          bool                  // When true, scan images for OS information
-	ConfigFile          string                // Path to SBOM configuration file
-	OutputFile          string                // Output location
-	Name                string                // Name to use in the resulting document
-	Namespace           string                // Namespace for the document (a unique URI)
-	CreatorPerson       string                // Document creator information
-	License             string                // Main license of the document
+	AnalyseLayers       bool   // A flag that controls if deep layer analysis should be performed
+	NoGitignore         bool   // Do not read exclusions from gitignore file
+	ProcessGoModules    bool   // Analyze go.mod to include data about packages
+	OnlyDirectDeps      bool   // Only include direct dependencies from go.mod
+	ScanLicenses        bool   // Try to look into files to determine their license
+	ScanImages          bool   // When true, scan images for OS information
+	ConfigFile          string // Path to SBOM configuration file
+	OutputFile          string // Output location
+	Name                string // Name to use in the resulting document
+	Namespace           string // Namespace for the document (a unique URI)
+	CreatorPerson       string // Document creator information
+	License             string // Main license of the document
+	WorkDir             string
 	Tarballs            []string              // A slice of docker archives (tar)
 	Archives            []string              // A list of archive files to add as packages
 	Files               []string              // A slice of naked files to include in the bom
@@ -163,6 +165,7 @@ func (builder *defaultDocBuilderImpl) GenerateDoc(
 	spdx.Options().AnalyzeLayers = genopts.AnalyseLayers
 	spdx.Options().ProcessGoModules = genopts.ProcessGoModules
 	spdx.Options().ScanImages = genopts.ScanImages
+	spdx.Options().WorkDir = genopts.WorkDir
 
 	if !util.Exists(opts.WorkDir) {
 		if err := os.MkdirAll(opts.WorkDir, os.FileMode(0o755)); err != nil {

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -70,14 +70,15 @@ func (spdx *SPDX) SetImplementation(impl spdxImplementation) {
 
 type Options struct {
 	AnalyzeLayers    bool
-	NoGitignore      bool     // Do not read exclusions from gitignore file
-	ProcessGoModules bool     // If true, spdx will check if dirs are go modules and analize the packages
-	OnlyDirectDeps   bool     // Only include direct dependencies from go.mod
-	ScanLicenses     bool     // Scan licenses from everypossible place unless false
-	AddTarFiles      bool     // Scan and add files inside of tarfiles
-	ScanImages       bool     // When true, scan container images for OS information
-	LicenseCacheDir  string   // Directory to cache SPDX license downloads
-	LicenseData      string   // Directory to store the SPDX licenses
+	NoGitignore      bool   // Do not read exclusions from gitignore file
+	ProcessGoModules bool   // If true, spdx will check if dirs are go modules and analize the packages
+	OnlyDirectDeps   bool   // Only include direct dependencies from go.mod
+	ScanLicenses     bool   // Scan licenses from everypossible place unless false
+	AddTarFiles      bool   // Scan and add files inside of tarfiles
+	ScanImages       bool   // When true, scan container images for OS information
+	LicenseCacheDir  string // Directory to cache SPDX license downloads
+	LicenseData      string // Directory to store the SPDX licenses
+	WorkDir          string
 	IgnorePatterns   []string // Patterns to ignore when scanning file
 }
 
@@ -200,6 +201,11 @@ func (spdx *SPDX) FileFromPath(filePath string) (*File, error) {
 		return nil, errors.New("file does not exist")
 	}
 	f := NewFile()
+
+	if spdx.Options().WorkDir != "" {
+		f.Entity.Options().WorkDir = spdx.Options().WorkDir
+	}
+
 	if err := f.ReadSourceFile(filePath); err != nil {
 		return nil, errors.Wrap(err, "creating file from path")
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
- add flag to set a work directory

before:

```console
$ ./output/bom-darwin-amd64 generate -f output/bom-darwin-amd64 -o bom.spdx

##### Files independent of packages

FileName: output/bom-darwin-amd64
SPDXID: SPDXRef-File-output-bom-darwin-amd64
FileChecksum: SHA1: abb58cbf63bb82882841af24a95ad62c56be0108
FileChecksum: SHA256: 552aedbe0854b11484340a119b499377f2944fa51795e039480522c7a2a7c5e2
FileChecksum: SHA512: a13d1484184d025bfd7afd125079f94dfdb6528de8964c7517d5b6d0f49ab66de5c88c3ebee843002180cc3a980910b155e0b88415e34b527d3963d75cccbacb
FileType: BINARY
FileType: APPLICATION
LicenseConcluded: NOASSERTION
LicenseInfoInFile: NOASSERTION
FileCopyrightText: NOASSERTION
`````


after the proposed changes

```console
$ ./output/bom-darwin-amd64 generate -f output/bom-darwin-amd64 -o bom.spdx -C output


##### Files independent of packages

FileName: bom-darwin-amd64
SPDXID: SPDXRef-File-bom-darwin-amd64
FileChecksum: SHA1: abb58cbf63bb82882841af24a95ad62c56be0108
FileChecksum: SHA256: 552aedbe0854b11484340a119b499377f2944fa51795e039480522c7a2a7c5e2
FileChecksum: SHA512: a13d1484184d025bfd7afd125079f94dfdb6528de8964c7517d5b6d0f49ab66de5c88c3ebee843002180cc3a980910b155e0b88415e34b527d3963d75cccbacb
FileType: BINARY
FileType: APPLICATION
LicenseConcluded: NOASSERTION
LicenseInfoInFile: NOASSERTION
FileCopyrightText: NOASSERTION
```


/assign @puerco 

#### Which issue(s) this PR fixes:


Fixes #52 


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add flag to set a work directory
```
