### PR TITLE
Make the document queryable (and ensure unique names)

### DIFF
--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -191,6 +191,7 @@ func (builder *defaultDocBuilderImpl) GenerateDoc(
 		if err != nil {
 			return nil, errors.Wrap(err, "generating package from directory")
 		}
+		doc.ensureUniqueElementID(pkg)
 
 		if err := doc.AddPackage(pkg); err != nil {
 			return nil, errors.Wrap(err, "adding directory package to document")
@@ -204,6 +205,8 @@ func (builder *defaultDocBuilderImpl) GenerateDoc(
 		if err != nil {
 			return nil, errors.Wrapf(err, "generating SPDX package from image ref %s", i)
 		}
+		doc.ensureUniqueElementID(p)
+		doc.ensureUniquePeerIDs(p.GetRelationships())
 		if err := doc.AddPackage(p); err != nil {
 			return nil, errors.Wrap(err, "adding package to document")
 		}
@@ -211,11 +214,13 @@ func (builder *defaultDocBuilderImpl) GenerateDoc(
 
 	// Process OCI image archives
 	for _, tb := range genopts.Tarballs {
-		logrus.Infof("Processing tarball %s", tb)
+		logrus.Infof("Processing image archive %s", tb)
 		p, err := spdx.PackageFromImageTarball(tb)
 		if err != nil {
 			return nil, errors.Wrap(err, "generating tarball package")
 		}
+		doc.ensureUniqueElementID(p)
+		doc.ensureUniquePeerIDs(p.GetRelationships())
 		if err := doc.AddPackage(p); err != nil {
 			return nil, errors.Wrap(err, "adding package to document")
 		}
@@ -228,6 +233,8 @@ func (builder *defaultDocBuilderImpl) GenerateDoc(
 		if err != nil {
 			return nil, errors.Wrap(err, "creating spdx package from archive")
 		}
+		doc.ensureUniqueElementID(p)
+		doc.ensureUniquePeerIDs(p.GetRelationships())
 		if err := doc.AddPackage(p); err != nil {
 			return nil, errors.Wrap(err, "adding package to document")
 		}
@@ -240,6 +247,7 @@ func (builder *defaultDocBuilderImpl) GenerateDoc(
 		if err != nil {
 			return nil, errors.Wrap(err, "adding file")
 		}
+		doc.ensureUniqueElementID(f)
 		if err := doc.AddFile(f); err != nil {
 			return nil, errors.Wrap(err, "adding file to document")
 		}

--- a/pkg/spdx/document.go
+++ b/pkg/spdx/document.go
@@ -428,6 +428,26 @@ func (d *Document) ensureUniqueElementID(o Object) {
 // ensureUniquePeerIDs gets a relationship collection and ensures all peers
 // have unique IDs
 func (d *Document) ensureUniquePeerIDs(rels *[]*Relationship) {
+	// First, ensure peer names are unique among themselves
+	seen := map[string]struct{}{}
+	for _, rel := range *rels {
+		if rel.Peer == nil || rel.Peer.SPDXID() == "" {
+			continue
+		}
+		testName := rel.Peer.SPDXID()
+		i := 0
+		for {
+			if _, ok := seen[testName]; !ok {
+				rel.Peer.SetSPDXID(testName)
+				seen[testName] = struct{}{}
+				break
+			}
+			i++
+			testName = fmt.Sprintf("%s-%04d", rel.Peer.SPDXID(), i)
+		}
+	}
+
+	// And then check against the document
 	for _, rel := range *rels {
 		if rel.Peer == nil {
 			continue

--- a/pkg/spdx/file.go
+++ b/pkg/spdx/file.go
@@ -190,3 +190,13 @@ func getFileContentType(path string) (string, error) {
 	contentType := http.DetectContentType(buffer)
 	return contentType, nil
 }
+
+// GetElementByID search the file and its peers looking for the
+// specified SPDX id. If found, the function returns a copy of
+// the object identified by the SPDX-ID provided
+func (f *File) GetElementByID(id string) Object {
+	if f.SPDXID() == id {
+		return f
+	}
+	return recursiveSearch(id, f, &map[string]struct{}{})
+}

--- a/pkg/spdx/object.go
+++ b/pkg/spdx/object.go
@@ -40,6 +40,7 @@ import (
 // objects. Currently this includes files and packages.
 type Object interface {
 	SPDXID() string
+	SetSPDXID(string)
 	ReadSourceFile(string) error
 	Render() (string, error)
 	BuildID(seeds ...string)
@@ -48,6 +49,7 @@ type Object interface {
 	GetRelationships() *[]*Relationship
 	ToProvenanceSubject() *intoto.Subject
 	getProvenanceSubjects(opts *ProvenanceOptions, seen *map[string]struct{}) []intoto.Subject
+	GetElementByID(string) Object
 }
 
 type Entity struct {
@@ -75,6 +77,11 @@ func (e *Entity) Options() *ObjectOptions {
 // SPDXID returns the SPDX reference string for the object
 func (e *Entity) SPDXID() string {
 	return e.ID
+}
+
+// SPDXID returns the SPDX reference string for the object
+func (e *Entity) SetSPDXID(id string) {
+	e.ID = id
 }
 
 // BuildID sets the file ID, optionally from a series of strings

--- a/pkg/spdx/object.go
+++ b/pkg/spdx/object.go
@@ -276,3 +276,6 @@ mloop:
 	}
 	return ret
 }
+
+// GetElementByID nil function to be overridden by package and file
+func (e *Entity) GetElementByID(string) Object { return nil }

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -388,6 +388,8 @@ func (p *Package) Draw(builder *strings.Builder, o *DrawingOptions, depth int, s
 	}
 }
 
+// ReadSourceFile reads a file from the filesystem and assigns its properties
+// to the package metadata
 func (p *Package) ReadSourceFile(path string) error {
 	if err := p.Entity.ReadSourceFile(path); err != nil {
 		return err
@@ -396,4 +398,13 @@ func (p *Package) ReadSourceFile(path string) error {
 		p.BuildID()
 	}
 	return nil
+}
+
+// GetElementByID search the package and its peers looking for the specified SPDX
+// id. If found, the function returns a copy of the object
+func (p *Package) GetElementByID(id string) Object {
+	if p.SPDXID() == id {
+		return p
+	}
+	return recursiveSearch(id, p, &map[string]struct{}{})
 }

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -246,3 +246,30 @@ func Banner() string {
 	}
 	return string(d)
 }
+
+// recursiveSearch is a function that recursively searches an object's peers
+// to find the specified SPDX ID. If found, returns a copy of the object.
+// nolint:gocritic // seen is a pointer recursively populated
+func recursiveSearch(id string, o Object, seen *map[string]struct{}) Object {
+	if o.SPDXID() == id {
+		return o
+	}
+	for _, rel := range *o.GetRelationships() {
+		if rel.Peer == nil {
+			continue
+		}
+
+		if _, ok := (*seen)[o.SPDXID()]; ok {
+			continue
+		}
+
+		if rel.Peer.SPDXID() == id {
+			return rel.Peer
+		}
+
+		if peerObject := recursiveSearch(id, rel.Peer, seen); peerObject != nil {
+			return peerObject
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## What type of PR is this?
/kind feature
/kind bug
#### What this PR does / why we need it:

This pull request introduces a new function to the document, File and Package objects to search for elements. This is inspired by the XML/HTML DOM and is called `document.GetElementByID()`. 

Passing an SPDX identifier to the function will return the element that matches the ID or nil if its not found.

**Bonus:** Leveraging these functions, we now ensure that packages generated from any source (dirs, images, etc) get unique IDs. Previously we tried to avoid name clashes by generating names hierarchically but that approach proved insufficient frequently.

#### Which issue(s) this PR fixes:

None
#### Special notes for your reviewer:

Unit tests for the new functions are included.

#### Does this PR introduce a user-facing change?

```release-note
- New XML-DOM inspired `x.GetElementByID()` allows querying documents, Files and Packages for elements that match an ID.
- The builder Object now ensures that generated SPDX IDs are unique across the document. 
```
