### PR TITLE
Add validation for empty directories

### DIFF
--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -803,6 +803,9 @@ func (di *spdxDefaultImplementation) PackageFromDirectory(opts *Options, dirPath
 
 	// Apply the ignore patterns to the list of files
 	fileList = di.ApplyIgnorePatterns(fileList, patterns)
+	if len(fileList) == 0 {
+		return nil, errors.Errorf("directory %s has no files to scan", dirPath)
+	}
 	logrus.Infof("Scanning %d files and adding them to the SPDX package", len(fileList))
 
 	pkg = NewPackage()


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR adds a validation for cases where the directory passed in for --dirs argument does not have any files left to scan after applying the ignore pattern. Without this check, bom generate gives an error like below which was not so clear to debug.

FATA generating doc: writing doc to ./out/istio-release.spdx: generating document markup: rendering pkg out: unable to get package verification code, package has no files



