### PR TITLE
Support Parsing SBOMs from STDIN

### DIFF
--- a/pkg/spdx/document.go
+++ b/pkg/spdx/document.go
@@ -61,6 +61,8 @@ ExternalDocumentRef:{{ extDocFormat $value }}
 {{ if .Creator -}}
 {{- if .Creator.Person }}Creator: Person: {{ .Creator.Person }}
 {{ end -}}
+{{- if .Creator.Organization }}Creator: Organization: {{ .Creator.Organization }}
+{{ end -}}
 {{- if .Creator.Tool -}}
 {{- range $key, $value := .Creator.Tool }}Creator: Tool: {{ $value }}
 {{ end -}}

--- a/pkg/spdx/file.go
+++ b/pkg/spdx/file.go
@@ -46,6 +46,9 @@ var fileTemplate = `{{ if .Name }}FileName: {{ .Name }}
 {{- end -}}
 {{- end -}}
 LicenseConcluded: {{ if .LicenseConcluded }}{{ .LicenseConcluded }}{{ else }}NOASSERTION{{ end }}
+{{ if .LicenseComments }}LicenseComments: <text>{{ .LicenseComments }}
+</text>
+{{ end -}}
 LicenseInfoInFile: {{ if .LicenseInfoInFile }}{{ .LicenseInfoInFile }}{{ else }}NOASSERTION{{ end }}
 FileCopyrightText: {{ if .CopyrightText }}<text>{{ .CopyrightText }}
 </text>{{ else }}NOASSERTION{{ end }}

--- a/pkg/spdx/object.go
+++ b/pkg/spdx/object.go
@@ -60,6 +60,7 @@ type Entity struct {
 	CopyrightText    string            // NOASSERTION
 	FileName         string            // Name of the file
 	LicenseConcluded string            // LicenseID o NOASSERTION
+	LicenseComments  string            // record any relevant background information or analysis that went in to arriving at the Concluded License
 	Opts             *ObjectOptions    // Entity options
 	Relationships    []*Relationship   // List of objects that have a relationship woth this package
 	Checksum         map[string]string // Colection of source file checksums

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -59,6 +59,9 @@ PackageLicenseConcluded: {{ if .LicenseConcluded }}{{ .LicenseConcluded }}{{ els
 {{ end -}}
 {{ if .Version }}PackageVersion: {{ .Version }}
 {{ end -}}
+{{ if .LicenseComments }}PackageLicenseComments: <text>{{ .LicenseComments }}
+</text>
+{{ end -}}
 PackageLicenseDeclared: {{ if .LicenseDeclared }}{{ .LicenseDeclared }}{{ else }}NOASSERTION{{ end }}
 PackageCopyrightText: {{ if .CopyrightText }}<text>{{ .CopyrightText }}
 </text>{{ else }}NOASSERTION{{ end }}
@@ -73,7 +76,6 @@ type Package struct {
 	VerificationCode     string   // 6486e016b01e9ec8a76998cefd0705144d869234
 	LicenseInfoFromFiles []string // GPL-3.0-or-later
 	LicenseDeclared      string   // GPL-3.0-or-later
-	LicenseComments      string   // record any relevant background information or analysis that went in to arriving at the Concluded License
 	Version              string   // Package version
 	Comment              string   // a place for the SPDX document creator to record any general comments
 

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -65,6 +65,8 @@ PackageLicenseConcluded: {{ if .LicenseConcluded }}{{ .LicenseConcluded }}{{ els
 {{ end -}}
 {{ if .Version }}PackageVersion: {{ .Version }}
 {{ end -}}
+{{ if .HomePage }}PackageHomePage: {{ .HomePage }}
+{{ end -}}
 {{ if .LicenseComments }}PackageLicenseComments: <text>{{ .LicenseComments }}
 </text>
 {{ end -}}
@@ -84,6 +86,7 @@ type Package struct {
 	LicenseDeclared      string   // GPL-3.0-or-later
 	Version              string   // Package version
 	Comment              string   // a place for the SPDX document creator to record any general comments
+	HomePage             string   // A web site that serves as the package home page
 
 	// Supplier: the actual distribution source for the package/directory
 	Supplier struct {

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -49,6 +49,12 @@ var packageTemplate = `##### Package: {{ .Name }}
 {{- end -}}
 PackageDownloadLocation: {{ if .DownloadLocation }}{{ .DownloadLocation }}{{ else }}NONE{{ end }}
 FilesAnalyzed: {{ .FilesAnalyzed }}
+{{ if .Supplier -}}
+{{- if .Supplier.Person }}PackageSupplier: Person: {{ .Supplier.Person }}
+{{ end -}}
+{{- if .Supplier.Organization }}PackageSupplier: Organization: {{ .Supplier.Organization }}
+{{ end -}}
+{{ end -}}
 {{ if .VerificationCode }}PackageVerificationCode: {{ .VerificationCode }}
 {{ end -}}
 PackageLicenseConcluded: {{ if .LicenseConcluded }}{{ .LicenseConcluded }}{{ else }}NOASSERTION{{ end }}

--- a/pkg/spdx/parser.go
+++ b/pkg/spdx/parser.go
@@ -242,6 +242,10 @@ func OpenDoc(path string) (doc *Document, err error) {
 			if value != NONE {
 				currentEntity.DownloadLocation = value
 			}
+		case "PackageLicenseComments", "LicenseComments":
+			if value != NONE {
+				currentEntity.LicenseComments = value
+			}
 			// Tags that apply top the doc
 		case "Created":
 			t, err := time.Parse("2006-01-02T15:04:05Z", value)

--- a/pkg/spdx/parser.go
+++ b/pkg/spdx/parser.go
@@ -186,6 +186,8 @@ func OpenDoc(path string) (doc *Document, err error) {
 			currentObject.(*Package).Comment = value
 		case "PackageFileName":
 			currentObject.(*Package).FileName = value
+		case "PackageHomePage":
+			currentObject.(*Package).HomePage = value
 		case "PackageLicenseInfoFromFiles":
 			have := false
 			// Check if we already have the license

--- a/pkg/spdx/parser.go
+++ b/pkg/spdx/parser.go
@@ -198,6 +198,23 @@ func OpenDoc(path string) (doc *Document, err error) {
 			if !have {
 				currentObject.(*Package).LicenseInfoFromFiles = append(currentObject.(*Package).LicenseInfoFromFiles, value)
 			}
+		case "PackageSupplier":
+			// Supplier has a tag/value format inside
+			match := tagRegExp.FindStringSubmatch(value)
+			if len(match) != 3 {
+				return nil, errors.Errorf("invalid creator tag syntax at line %d", i)
+			}
+			switch match[1] {
+			case "Person":
+				currentObject.(*Package).Supplier.Person = match[2]
+			case "Organization":
+				currentObject.(*Package).Supplier.Organization = match[2]
+			default:
+				return nil, errors.Errorf(
+					"invalid supplier tag '%s' syntax at line %d, valid values are 'Organization' or 'Person'",
+					match[1], i,
+				)
+			}
 		case "LicenseInfoInFile":
 			if value != NONE {
 				currentObject.(*File).LicenseInfoInFile = value


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup
/kind feature

#### What this PR does / why we need it:

This commit enables the parser to read SBOMs from STDIN when specifying the SBOM path as `-`. When - is detected as filename, bom will buffer the SBOM to stdin and parse it from there.

In addition this PR adds support for some missing tags to both the parser and renderer:

- `PackageSupplier`
- `LicenseComments` and `PackageLicenseComments`
- `PackageHomePage`

It also fixes a bug where a document's creator organization was missing from the SBOM.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/assign @cpanato @jeremyrickard 

#### Does this PR introduce a user-facing change?

```release-note
- SBOMs can now be read from STDIN by passing `-` as a path wherever a filename is expected
- Added support to render and parse `PackageSupplier`, `PackageHomePage`, `LicenseComments` and `PackageLicenseComments`
- Fixed a bug where the creator organization was missing from the SBOM output.
```
