### PR TITLE
Generate purls from read sources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
+	github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.3.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -696,6 +696,10 @@ github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mo
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
+github.com/package-url/packageurl-go v0.1.0 h1:efWBc98O/dBZRg1pw2xiDzovnlMjCa9NPnfaiBduh8I=
+github.com/package-url/packageurl-go v0.1.0/go.mod h1:C/ApiuWpmbpni4DIOECf6WCjFUZV7O1Fx7VAzrZHgBw=
+github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a h1:tkTSd1nhioPqi5Whu3CQ79UjPtaGOytqyNnSCVOqzHM=
+github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/go.sum
+++ b/go.sum
@@ -696,8 +696,6 @@ github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mo
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
-github.com/package-url/packageurl-go v0.1.0 h1:efWBc98O/dBZRg1pw2xiDzovnlMjCa9NPnfaiBduh8I=
-github.com/package-url/packageurl-go v0.1.0/go.mod h1:C/ApiuWpmbpni4DIOECf6WCjFUZV7O1Fx7VAzrZHgBw=
 github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a h1:tkTSd1nhioPqi5Whu3CQ79UjPtaGOytqyNnSCVOqzHM=
 github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/pkg/osinfo/container_scanner.go
+++ b/pkg/osinfo/container_scanner.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strings"
 
+	purl "github.com/package-url/packageurl-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -48,10 +49,14 @@ func (ct *ContainerScanner) ReadOSPackages(layers []string) (
 		}
 	}
 
-	if osKind == OSDebian {
-		return ct.ReadDebianPackages(layers)
+	switch osKind {
+	case OSDebian, OSUbuntu:
+		layerNum, packages, err = ct.ReadDebianPackages(layers)
+	default:
+		return 0, nil, nil
 	}
-	return 0, nil, nil
+
+	return layerNum, packages, err
 }
 
 // ReadDebianPackages scans through a set of container layers looking for the
@@ -89,9 +94,14 @@ func (ct *ContainerScanner) ReadDebianPackages(layers []string) (layer int, pk *
 }
 
 type PackageDBEntry struct {
-	Package      string
-	Version      string
-	Architecture string
+	Package         string
+	Version         string
+	Architecture    string
+	Type            string // purl package type (ref: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst)
+	Namespace       string // purl namespace
+	MaintainerName  string
+	MaintainerEmail string
+	HomePage        string
 }
 
 func (ct *ContainerScanner) parseDpkgDB(dbPath string) (*[]PackageDBEntry, error) {
@@ -105,28 +115,39 @@ func (ct *ContainerScanner) parseDpkgDB(dbPath string) (*[]PackageDBEntry, error
 	scanner := bufio.NewScanner(file)
 	var curPkg *PackageDBEntry
 	for scanner.Scan() {
-		if strings.HasPrefix(scanner.Text(), "Package:") {
+		parts := strings.SplitN(scanner.Text(), ":", 2)
+		if len(parts) < 2 {
+			continue
+		}
+
+		switch parts[0] {
+		case "Package":
 			if curPkg != nil {
 				db = append(db, *curPkg)
 			}
 			curPkg = &PackageDBEntry{
-				Package: strings.TrimSpace(strings.TrimPrefix(scanner.Text(), "Package:")),
+				Package: strings.TrimSpace(parts[1]),
+				Type:    purl.TypeDebian,
 			}
-		}
-
-		if strings.HasPrefix(scanner.Text(), "Architecture:") {
+		case "Architecture":
 			if curPkg != nil {
-				curPkg.Architecture = strings.TrimSpace(
-					strings.TrimPrefix(scanner.Text(), "Architecture:"),
-				)
+				curPkg.Architecture = strings.TrimSpace(parts[1])
 			}
-		}
-
-		if strings.HasPrefix(scanner.Text(), "Version:") {
+		case "Version":
 			if curPkg != nil {
-				curPkg.Version = strings.TrimSpace(
-					strings.TrimPrefix(scanner.Text(), "Version:"),
-				)
+				curPkg.Version = strings.TrimSpace(parts[1])
+			}
+		case "Homepage":
+			if curPkg != nil {
+				curPkg.HomePage = strings.TrimSpace(parts[1])
+			}
+		case "Maintainer":
+			if curPkg != nil {
+				mparts := strings.SplitN(parts[1], "<", 2)
+				if len(mparts) == 2 {
+					curPkg.MaintainerName = mparts[0]
+					curPkg.MaintainerEmail = strings.TrimSuffix(mparts[1], ">")
+				}
 			}
 		}
 	}

--- a/pkg/osinfo/layer_scanner.go
+++ b/pkg/osinfo/layer_scanner.go
@@ -30,7 +30,10 @@ import (
 
 const (
 	OSDebian     = "debian"
+	OSUbuntu     = "ubuntu"
 	OSFedora     = "fedora"
+	OSCentos     = "centos"
+	OSRHEL       = "rhel"
 	OSAlpine     = "alpine"
 	OSDistroless = "distroless"
 )
@@ -60,11 +63,19 @@ func (loss *LayerScanner) OSType(layerPath string) (ostype string, err error) {
 	}
 
 	if strings.Contains(osrelease, "NAME=\"Ubuntu\"") {
-		return OSDebian, nil
+		return OSUbuntu, nil
 	}
 
 	if strings.Contains(osrelease, "NAME=\"Fedora Linux\"") {
 		return OSFedora, nil
+	}
+
+	if strings.Contains(osrelease, "NAME=\"CentOS Linux\"") {
+		return OSCentos, nil
+	}
+
+	if strings.Contains(osrelease, "NAME=\"Red Hat Enterprise Linux\"") {
+		return OSRHEL, nil
 	}
 
 	if strings.Contains(osrelease, "NAME=\"Alpine Linux\"") {

--- a/pkg/spdx/gomod.go
+++ b/pkg/spdx/gomod.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/nozzle/throttler"
+	purl "github.com/package-url/packageurl-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/mod/modfile"
@@ -104,7 +105,36 @@ func (pkg *GoPackage) ToSPDXPackage() (*Package, error) {
 	spdxPackage.LicenseConcluded = pkg.LicenseID
 	spdxPackage.Version = strings.TrimSuffix(pkg.Revision, "+incompatible")
 	spdxPackage.CopyrightText = pkg.CopyrightText
+	if packageurl := pkg.PackageURL(); packageurl != "" {
+		spdxPackage.ExternalRefs = append(spdxPackage.ExternalRefs, ExternalRef{
+			Category: "PACKAGE-MANAGER",
+			Type:     "purl",
+			Locator:  packageurl,
+		})
+	}
 	return spdxPackage, nil
+}
+
+// PackageURL returns a purl if the go package has enough data to generate
+// one. If data is missing, it will return an empty string
+func (pkg *GoPackage) PackageURL() string {
+	parts := strings.Split(pkg.ImportPath, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	pname := parts[len(parts)-1]
+	namespace := strings.TrimSuffix(parts[0], "/"+pname)
+
+	// We require type, package, namespace and version at the very
+	// least to generate a purl
+	if pname == "" || pkg.Revision == "" || namespace == "" {
+		return ""
+	}
+
+	return purl.NewPackageURL(
+		purl.TypeGolang, namespace, pname,
+		strings.TrimSuffix(pkg.Revision, "+incompatible"), nil, "",
+	).ToString()
 }
 
 type GoModImplementation interface {

--- a/pkg/spdx/gomod.go
+++ b/pkg/spdx/gomod.go
@@ -18,6 +18,7 @@ package spdx
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -101,7 +102,14 @@ func (pkg *GoPackage) ToSPDXPackage() (*Package, error) {
 		spdxPackage.Name += "@" + strings.TrimSuffix(pkg.Revision, "+incompatible")
 	}
 	spdxPackage.BuildID()
-	spdxPackage.DownloadLocation = repo.Repo
+	if strings.Contains(pkg.Revision, "+incompatible") {
+		spdxPackage.DownloadLocation = repo.VCS.Scheme[0] + "+" + repo.Repo
+	} else {
+		spdxPackage.DownloadLocation = fmt.Sprintf(
+			"https://proxy.golang.org/%s/@v/%s.zip", pkg.ImportPath,
+			strings.TrimSuffix(pkg.Revision, "+incompatible"),
+		)
+	}
 	spdxPackage.LicenseConcluded = pkg.LicenseID
 	spdxPackage.Version = strings.TrimSuffix(pkg.Revision, "+incompatible")
 	spdxPackage.CopyrightText = pkg.CopyrightText

--- a/pkg/spdx/gomod_test.go
+++ b/pkg/spdx/gomod_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageURL(t *testing.T) {
+	for _, tc := range []struct {
+		pkg      GoPackage
+		expected string
+	}{
+		// No error
+		{GoPackage{ImportPath: "package/name", Revision: "v1.0.0"}, "pkg:golang/package/name@v1.0.0"},
+		// No import path
+		{GoPackage{ImportPath: "", Revision: "v1.0.0"}, ""},
+		// Incomplete import path
+		{GoPackage{ImportPath: "package", Revision: "v1.0.0"}, ""},
+		// No revision
+		{GoPackage{ImportPath: "package/name", Revision: ""}, ""},
+	} {
+		require.Equal(t, tc.expected, tc.pkg.PackageURL())
+	}
+}

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -743,10 +743,24 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 
 		// If we got the OS data from the scanner, add the packages:
 		if i == layerNum && osPackageData != nil {
-			for _, osPkgData := range *osPackageData {
+			for i := range *osPackageData {
 				ospk := NewPackage()
-				ospk.Name = osPkgData.Package + "-" + osPkgData.Version
-				ospk.Version = osPkgData.Version
+				ospk.Name = (*osPackageData)[i].Package + "-" + (*osPackageData)[i].Version
+				ospk.Version = (*osPackageData)[i].Version
+				ospk.HomePage = (*osPackageData)[i].HomePage
+				if (*osPackageData)[i].MaintainerName != "" {
+					ospk.Supplier.Person = (*osPackageData)[i].MaintainerName
+					if (*osPackageData)[i].MaintainerEmail != "" {
+						ospk.Supplier.Person += fmt.Sprintf(" (%s)", (*osPackageData)[i].MaintainerEmail)
+					}
+				}
+				if (*osPackageData)[i].PackageURL() != "" {
+					ospk.ExternalRefs = append(ospk.ExternalRefs, ExternalRef{
+						Category: "PACKAGE-MANAGER",
+						Type:     "purl",
+						Locator:  (*osPackageData)[i].PackageURL(),
+					})
+				}
 				ospk.BuildID(pkg.ID)
 				if err := pkg.AddPackage(ospk); err != nil {
 					return nil, errors.Wrap(err, "adding OS package to container layer")

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -67,6 +67,9 @@ PackageLicenseConcluded: {{ if .LicenseConcluded }}{{ .LicenseConcluded }}{{ els
 {{ end -}}
 {{ if .HomePage }}PackageHomePage: {{ .HomePage }}
 {{ end -}}
+{{ if .ExternalRefs }}{{- range $key, $value := .ExternalRefs -}}ExternalRef: {{ $value.Category }} {{ $value.Type }} {{ $value.Locator }}
+{{ end -}}
+{{ end -}}
 {{ if .LicenseComments }}PackageLicenseComments: <text>{{ .LicenseComments }}
 </text>
 {{ end -}}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

bom will now annotate system packages, golang dependencies and OCI images (in a registry) with a [package URL](https://github.com/package-url/purl-spec). Reading this annotation makes it easier to detect what kind of source the spdx package is describing.

Having purls in all artifacts will now allow answering questions like _Does this SBOM describe an image?, do we have golang dependency information? what about the system packages in this image?_ 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Sample run:

```
go run cmd/bom/main.go generate --image=nginx | grep purl

ExternalRef: PACKAGE-MANAGER purl pkg:oci/nginx@sha256:1c13bc6de5dfca749c377974146ac05256791ca2fe1979fc8e8278bf0121d285?repository_url=index.docker.io%2Flibrary&tag=nginx
ExternalRef: PACKAGE-MANAGER purl pkg:oci/nginx@sha256:2468d48e476b6a079eb646e87620f96ce1818ac0c5b3a8450532cea64b3421f4?arch=amd64&repository_url=index.docker.io%2Flibrary
ExternalRef: PACKAGE-MANAGER purl pkg:deb/debian/adduser@3.118?arch=all
ExternalRef: PACKAGE-MANAGER purl pkg:deb/debian/apt@2.2.4?arch=amd64
ExternalRef: PACKAGE-MANAGER purl pkg:deb/debian/base-files@11.1+deb11u2?arch=amd64
ExternalRef: PACKAGE-MANAGER purl pkg:deb/debian/base-passwd@3.5.51?arch=amd64
ExternalRef: PACKAGE-MANAGER purl pkg:deb/debian/bash@5.1-2+b3?arch=amd64
ExternalRef: PACKAGE-MANAGER purl pkg:deb/debian/bsdutils@1:2.36.1-8+deb11u1?arch=amd64
ExternalRef: PACKAGE-MANAGER purl pkg:deb/debian/ca-certificates@20210119?arch=all
ExternalRef: PACKAGE-MANAGER purl pkg:deb/debian/coreutils@8.32-4+b1?arch=amd64
ExternalRef: PACKAGE-MANAGER purl pkg:deb/debian/curl@7.74.0-1.3+deb11u1?arch=amd64
ExternalRef: PACKAGE-MANAGER purl pkg:deb/debian/dash@0.5.11+git20200708+dd9ef66-5?arch=amd64
ExternalRef: PACKAGE-MANAGER purl pkg:deb/debian/debconf@1.5.77?arch=all
ExternalRef: PACKAGE-MANAGER purl pkg:deb/debian/debian-archive-keyring@2021.1.1?arch=all
... (lots more)
```

/assign @cpanato 
/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
bom now adds `ExternalRef`s with Package URLs (purls) for all system packages, go dependencies and OCI images. 
```
