### PR TITLE
Fix panic when emtpy os deps, readd document

### DIFF
--- a/cmd/bom/cmd/document.go
+++ b/cmd/bom/cmd/document.go
@@ -35,6 +35,7 @@ func AddDocument(parent *cobra.Command) {
 	}
 
 	AddOutline(documentCmd)
+	parent.AddCommand(documentCmd)
 }
 
 func AddOutline(parent *cobra.Command) {

--- a/pkg/osinfo/container_scanner.go
+++ b/pkg/osinfo/container_scanner.go
@@ -59,12 +59,19 @@ func (ct *ContainerScanner) ReadOSPackages(layers []string) (
 		return 0, nil, nil
 	}
 
-	for i := range *packages {
-		(*packages)[i].Type = purlType
-		(*packages)[i].Namespace = osKind
-	}
-
+	ct.setPurlData(purlType, osKind, packages)
 	return layerNum, packages, err
+}
+
+// setPurlData stamps al found packages with the purl type and NS
+func (ct *ContainerScanner) setPurlData(ptype, pnamespace string, packages *[]PackageDBEntry) {
+	if packages == nil {
+		return
+	}
+	for i := range *packages {
+		(*packages)[i].Type = ptype
+		(*packages)[i].Namespace = pnamespace
+	}
 }
 
 // ReadDebianPackages scans through a set of container layers looking for the


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes two bugs in bom:

Fixes a panic where `bom` would die when no OS packages could be read from a debian base layer.

It also fixes a bug that disconnected the entire document subcommand during the last command refactor

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
- Fixed a panic where `bom` would die when no OS packages could be read from a debian base layer.
- Fixed a bug that disconnected the entire document subcommand from the main cobra command
```
