### PR TITLE
update build image to use latest go

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -19,7 +19,7 @@ steps:
       echo "Checking out ${_PULL_BASE_REF}"
       git checkout ${_PULL_BASE_REF}
 
-  - name: 'gcr.io/k8s-staging-releng/releng-ci:latest-go1.17'
+  - name: 'gcr.io/k8s-staging-releng/releng-ci:latest-go1.17-bullseye'
     dir: "go/src/sigs.k8s.io/bom"
     entrypoint: go
     env:


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

the image `gcr.io/k8s-staging-releng/releng-ci:latest-go1.17` is not being generated and that image has go 1.17rc2 we now build two configs for the latest tag:

- `gcr.io/k8s-staging-releng/releng-ci:latest-go1.17-bullseye`
- `gcr.io/k8s-staging-releng/releng-ci:latest-go1.17-buster`

let's use the one with the bullseye for now

to show that we are building bom with 1.17rc2

```
$ docker run gcr.io/k8s-staging-bom/bom:dcaf425 version
Unable to find image 'gcr.io/k8s-staging-bom/bom:dcaf425' locally
dcaf425: Pulling from k8s-staging-bom/bom
b0b160e41cf3: Pull complete
250c06f7c38e: Pull complete
2be54ece9dd9: Pull complete
Digest: sha256:f16abe64f52e60b519c0acfc205f955e6d304a8529282393ff12f437ff86833c
Status: Downloaded newer image for gcr.io/k8s-staging-bom/bom:dcaf425
  ____     ___    __  __
 | __ )   / _ \  |  \/  |
 |  _ \  | | | | | |\/| |
 | |_) | | |_| | | |  | |
 |____/   \___/  |_|  |_|
bom: A tool for working with SPDX manifests

GitVersion:    v0.2.2-73-gdcaf425
GitCommit:     dcaf425
GitTreeState:  clean
BuildDate:     2022-03-29T05:49:11Z
GoVersion:     go1.17rc2
Compiler:      gc
Platform:      linux/arm64
```

/assign @puerco 


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
