### PR TITLE
Specify SVC account in promo manifest

### DIFF
--- a/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
+++ b/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
@@ -3,5 +3,5 @@ registries:
 - name: gcr.io/k8s-staging-bom
   src: true
 - name: gcr.io/ulabs-cloud-tests/bom-canary
-  #service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Test specifying the service account in the promo manifest

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
NONE
```
