### PR TITLE
Delete canary builds manifests

### DIFF
--- a/canary/images/k8s-staging-bom/images.yaml
+++ b/canary/images/k8s-staging-bom/images.yaml
@@ -1,4 +1,0 @@
-- name: bom
-  dmap:
-    "sha256:631ff0f765b4b1ff0b3c81d73698f557f2291aebc822eedf4d265a9ec611af42": ["v0.3.0-rc1"]
-

--- a/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
+++ b/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
@@ -2,6 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-bom
   src: true
-- name: gcr.io/ulabs-cloud-tests/bom-canary
+- name: gcr.io/k8s-staging-bom/bom-canary
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 

--- a/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
+++ b/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
@@ -1,7 +1,0 @@
-# Image promotion to canary test repository
-registries:
-- name: gcr.io/k8s-staging-bom
-  src: true
-- name: gcr.io/k8s-staging-bom/bom-canary
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR removes the test image promotion manifests we had set up to build canary images for bom. The manifests now live in k8s-sigs/promo-tools.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

/assign @cpanato 

#### Does this PR introduce a user-facing change?
```release-note
The bom project now features canary releases published to the staging bucket
```
