### PR TITLE
Bug fixes in go dependencies 

### DIFF
--- a/pkg/spdx/gomod.go
+++ b/pkg/spdx/gomod.go
@@ -295,6 +295,11 @@ func (mod *GoModule) BuildFullPackageList(g *modfile.File) (packageList []*GoPac
 			return nil, errors.Wrap(err, "decoding module list")
 		}
 		if m.Module.Path != "" {
+			// If this is the main package (ie the module itself) skip
+			if m.Module.Main {
+				continue
+			}
+
 			if _, ok := list[m.Module.Path]; !ok {
 				list[m.Module.Path] = map[string]*ModEntry{}
 			}

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -606,7 +606,13 @@ func (di *spdxDefaultImplementation) GetGoDependencies(
 		return nil, errors.Wrap(err, "opening new module path")
 	}
 
-	defer func() { err = mod.RemoveDownloads() }()
+	defer func() {
+		preErr := err
+		err = mod.RemoveDownloads()
+		if preErr != nil {
+			err = preErr
+		}
+	}()
 	if opts.ScanLicenses {
 		if errScan := mod.ScanLicenses(); err != nil {
 			return nil, errScan

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -623,7 +623,9 @@ func (di *spdxDefaultImplementation) GetGoDependencies(
 	for _, goPkg := range mod.Packages {
 		spdxPkg, err := goPkg.ToSPDXPackage()
 		if err != nil {
-			return nil, errors.Wrap(err, "converting go module to spdx package")
+			// If a dependency cannot be converted, warn but do not die
+			logrus.Error(fmt.Errorf("converting go dependency to spdx package: %w", err))
+			continue
 		}
 		spdxPackages = append(spdxPackages, spdxPkg)
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR fixes three bugs in the go dependency code:

1. It fixes a bug in the dependency generator where var scope was handled wrong and errors were not being surfaced correctly
2. It makes the go module parser more permissive preventing a fatal error when a dependency cannot be converted to a SPDX package
3. Finally, it fixes a bug where the go module being analyzed was listed as a dependency 

#### Which issue(s) this PR fixes:

Fixes #61

#### Special notes for your reviewer:

/assign @cpanato @justaugustus @saschagrunert 
/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
- Fixes a bug in the go dependency generator where var scope was handled wrong and errors were not being surfaced correctly
- The go module parser is now more permissive preventing a fatal error when a dependency cannot be converted to a SPDX package
- Fixed a bug where the go module being analyzed was incorrectly listed as a dependency of itself

```
