### PR TITLE
Drop revision from spdx packages names generated from go modules

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -90,7 +90,7 @@ func Verify() error {
 	}
 
 	fmt.Println("Running golangci-lint...")
-	if err := mage.RunGolangCILint("v1.44.2", false); err != nil {
+	if err := mage.RunGolangCILint("v1.45.2", false); err != nil {
 		return err
 	}
 

--- a/pkg/license/implementation.go
+++ b/pkg/license/implementation.go
@@ -60,7 +60,8 @@ func (d *ReaderDefaultImpl) ClassifyFile(path string) (licenseTag string, moreTa
 
 // ClassifyLicenseFiles takes a list of paths and tries to find return all licenses found in it
 func (d *ReaderDefaultImpl) ClassifyLicenseFiles(paths []string) (
-	licenseList []*ClassifyResult, unrecognizedPaths []string, err error) {
+	licenseList []*ClassifyResult, unrecognizedPaths []string, err error,
+) {
 	licenseList = []*ClassifyResult{}
 	// Run the files through the clasifier
 	for _, f := range paths {

--- a/pkg/provenance/statement.go
+++ b/pkg/provenance/statement.go
@@ -134,7 +134,8 @@ func (si *defaultStatementImplementation) AddSubject(
 // ReadSubjectsFromDir reads a directory and adds all files found as
 // subjects of the statement.
 func (si *defaultStatementImplementation) ReadSubjectsFromDir(
-	s *Statement, dirPath string) (err error) {
+	s *Statement, dirPath string,
+) (err error) {
 	// Traverse the directory
 	if err := fs.WalkDir(os.DirFS(dirPath), ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -308,7 +308,8 @@ func (builder *defaultDocBuilderImpl) WriteDoc(doc *Document, path string) error
 // ReadYamlConfiguration reads a yaml configuration and
 // set the values in an options struct
 func (builder *defaultDocBuilderImpl) ReadYamlConfiguration(
-	path string, opts *DocGenerateOptions) (err error) {
+	path string, opts *DocGenerateOptions,
+) (err error) {
 	yamldata, err := os.ReadFile(path)
 	if err != nil {
 		return errors.Wrap(err, "reading yaml SBOM configuration")

--- a/pkg/spdx/gomod.go
+++ b/pkg/spdx/gomod.go
@@ -484,7 +484,8 @@ func (di *GoModDefaultImpl) LicenseReader() (*license.Reader, error) {
 
 // ScanPackageLicense scans a package for licensing info
 func (di *GoModDefaultImpl) ScanPackageLicense(
-	pkg *GoPackage, reader *license.Reader, opts *GoModuleOptions) error {
+	pkg *GoPackage, reader *license.Reader, opts *GoModuleOptions,
+) error {
 	dir := pkg.LocalDir
 	if dir == "" && pkg.LocalInstall != "" {
 		dir = pkg.LocalInstall

--- a/pkg/spdx/gomod.go
+++ b/pkg/spdx/gomod.go
@@ -97,11 +97,10 @@ func (pkg *GoPackage) ToSPDXPackage() (*Package, error) {
 		return nil, errors.Wrap(err, "building repository from package import path")
 	}
 	spdxPackage := NewPackage()
+	spdxPackage.Options().Prefix = "gomod"
 	spdxPackage.Name = pkg.ImportPath
-	if pkg.Revision != "" {
-		spdxPackage.Name += "@" + strings.TrimSuffix(pkg.Revision, "+incompatible")
-	}
-	spdxPackage.BuildID()
+
+	spdxPackage.BuildID(pkg.ImportPath, pkg.Revision)
 	if strings.Contains(pkg.Revision, "+incompatible") {
 		spdxPackage.DownloadLocation = repo.VCS.Scheme[0] + "+" + repo.Repo
 	} else {

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -204,7 +204,8 @@ func getImageReferences(referenceString string) ([]struct {
 	Tag    string
 	Arch   string
 	OS     string
-}, error) {
+}, error,
+) {
 	ref, err := name.ParseReference(referenceString)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing image reference %s", referenceString)
@@ -363,7 +364,8 @@ func (di *spdxDefaultImplementation) PullImagesToArchive(
 	Archive   string
 	Arch      string
 	OS        string
-}, err error) {
+}, err error,
+) {
 	images = []struct {
 		Reference string
 		Archive   string
@@ -664,7 +666,8 @@ func (di *spdxDefaultImplementation) GetDirectoryLicense(
 // purlFromImage builds a purl from an image reference
 func (*spdxDefaultImplementation) purlFromImage(img struct {
 	Reference, Archive, Arch, OS string
-}) string {
+},
+) string {
 	// OCI type urls don't have a namespace ref:
 	// https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#oci
 

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -227,7 +227,8 @@ func (spdx *SPDX) PullImagesToArchive(reference, path string) ([]struct {
 	Archive   string
 	Arch      string
 	OS        string
-}, error) {
+}, error,
+) {
 	return spdx.impl.PullImagesToArchive(reference, path)
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This commit modifies the way we name the spdx packages generated from go modules. We now drop the version and let
the package be named only the module import path (version is still included in the appropriate field)

```
BEFORE:
PackageName: golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1

NOW:
PackageName: golang.org/x/xerrors
```

This makes the bom sbom match the way ko, apko and other tools name their packages. It also adds a new test to check the
fields generated for the package.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

**Update:** Pushed two extra commits to fix the CI. It appears that the version of golangci-lint has a problem when running in the test environment. One bumps golangci-lint, the second goumpt-s a bunch of files to satisfy the new linter.

/assign @jeremyrickard @cpanato @saschagrunert 

#### Does this PR introduce a user-facing change?

```release-note
Package names generated from go modules do not include the module's version anymore.
```
