### PR TITLE
cmd/bom: replace github.com/pkg/errors dependency with native error wrapping

### DIFF
--- a/cmd/bom/cmd/document.go
+++ b/cmd/bom/cmd/document.go
@@ -17,9 +17,9 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/bom/pkg/spdx"
@@ -54,13 +54,13 @@ func AddQuery(parent *cobra.Command) {
 			}
 			doc, err := spdx.OpenDoc(args[0])
 			if err != nil {
-				return errors.Wrap(err, "opening document")
+				return fmt.Errorf("opening document: %w", err)
 			}
 
 			// Parse the purl
 			pquery, err := purl.FromString(args[1])
 			if err != nil {
-				return errors.Wrap(err, "parsing purl")
+				return fmt.Errorf(err, "parsing purl")
 			}
 
 			// Create the purl we will use to query
@@ -114,15 +114,15 @@ set the --spdx-ids to only output the IDs of the entities.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				cmd.Help() // nolint:errcheck
-				return errors.New("You should only specify one file")
+				return errors.New("you should only specify one file")
 			}
 			doc, err := spdx.OpenDoc(args[0])
 			if err != nil {
-				return errors.Wrap(err, "opening doc")
+				return fmt.Errorf("opening doc: %w", err)
 			}
 			output, err := doc.Outline(outlineOpts)
 			if err != nil {
-				return errors.Wrap(err, "generating document outline")
+				return fmt.Errorf("generating document outline: %w", err)
 			}
 			fmt.Println(spdx.Banner())
 			fmt.Println(output)

--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -17,11 +17,11 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -82,7 +82,7 @@ func (opts *generateOptions) Validate() error {
 		// Check if image archives exist
 		for i, iPath := range col.Items {
 			if !isGlob(iPath) && !util.Exists(iPath) {
-				return errors.Errorf("%s #%d not found (%s)", col.Name, i+1, iPath)
+				return fmt.Errorf("%s #%d not found (%s)", col.Name, i+1, iPath)
 			}
 		}
 	}
@@ -127,11 +127,11 @@ completed by a later stage in your CI/CD pipeline. See the
 				}
 				file, err := os.Open(arg)
 				if err != nil {
-					return errors.Wrapf(err, "checking argument %d", i)
+					return fmt.Errorf("checking argument %d: %w", i, err)
 				}
 				fileInfo, err := file.Stat()
 				if err != nil {
-					return errors.Wrapf(err, "calling stat on argument %d", i)
+					return fmt.Errorf("calling stat on argument %d: %w", i, err)
 				}
 				if fileInfo.IsDir() {
 					genOpts.directories = append(genOpts.directories, arg)
@@ -140,7 +140,7 @@ completed by a later stage in your CI/CD pipeline. See the
 
 			if err := genOpts.Validate(); err != nil {
 				cmd.Help() // nolint:errcheck // We already errored
-				return errors.Wrap(err, "validating command line options")
+				return fmt.Errorf("validating command line options: %w", err)
 			}
 
 			return generateBOM(genOpts)
@@ -174,7 +174,7 @@ completed by a later stage in your CI/CD pipeline. See the
 	if err := generateCmd.PersistentFlags().MarkDeprecated(
 		"tarball", "tarball has been renamed to image-archive",
 	); err != nil {
-		logrus.Fatal(errors.Wrap(err, "marking flag as deprecated"))
+		logrus.Fatalf("marking flag as deprecated: %v", err)
 	}
 
 	generateCmd.PersistentFlags().StringSliceVar(
@@ -340,7 +340,7 @@ func generateBOM(opts *generateOptions) error {
 	}
 	doc, err := builder.Generate(builderOpts)
 	if err != nil {
-		return errors.Wrap(err, "generating doc")
+		return fmt.Errorf("generating doc: %w", err)
 	}
 
 	if opts.outputFile == "" {
@@ -364,7 +364,7 @@ func generateBOM(opts *generateOptions) error {
 		if err := doc.WriteProvenanceStatement(
 			spdx.DefaultProvenanceOptions, opts.provenancePath,
 		); err != nil {
-			return errors.Wrap(err, "writing SBOM as provenance statement")
+			return fmt.Errorf("writing SBOM as provenance statement: %w", err)
 		}
 	}
 

--- a/cmd/bom/cmd/query.go
+++ b/cmd/bom/cmd/query.go
@@ -17,10 +17,10 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/bom/pkg/query"
@@ -58,7 +58,7 @@ Example:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
 				cmd.Help() // nolint:errcheck
-				return errors.New("You should only specify one file")
+				return errors.New("you should only specify one file")
 			}
 
 			q := query.New()

--- a/cmd/bom/cmd/validate.go
+++ b/cmd/bom/cmd/validate.go
@@ -17,11 +17,12 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -55,15 +56,15 @@ for checking files.
 				if util.Exists(arg) {
 					file, err := os.Open(arg)
 					if err != nil {
-						return errors.Wrapf(err, "checking argument %d", i)
+						return fmt.Errorf("checking argument %d: %w", i, err)
 					}
 					defer file.Close()
 					fileInfo, err := file.Stat()
 					if err != nil {
-						return errors.Wrapf(err, "calling stat on argument %d", i)
+						return fmt.Errorf("calling stat on argument %d: %w", i, err)
 					}
 					if fileInfo.IsDir() {
-						return errors.Errorf(
+						return fmt.Errorf(
 							"the path %s is a directory, only files are supported at this time",
 							file.Name(),
 						)
@@ -74,7 +75,7 @@ for checking files.
 						valOpts.files = append(valOpts.files, file.Name())
 					}
 				} else {
-					return errors.Errorf("the path specified at %s does not exist", arg)
+					return fmt.Errorf("the path specified at %s does not exist", arg)
 				}
 			}
 			return validateArtifacts(valOpts)
@@ -117,7 +118,7 @@ func (opts *validateOptions) Validate() error {
 
 func validateArtifacts(opts validateOptions) error {
 	if err := opts.Validate(); err != nil {
-		return errors.Wrap(err, "validating command line options")
+		return fmt.Errorf("validating command line options: %w", err)
 	}
 
 	if !opts.exitCode {
@@ -125,12 +126,12 @@ func validateArtifacts(opts validateOptions) error {
 	}
 	doc, err := spdx.OpenDoc(opts.sbomPath)
 	if err != nil {
-		return errors.Wrap(err, "opening doc")
+		return fmt.Errorf("opening doc: %w", err)
 	}
 
 	res, err := doc.ValidateFiles(opts.files)
 	if err != nil {
-		return errors.Wrap(err, "validating files")
+		return fmt.Errorf("validating files: %w", err)
 	}
 
 	data := [][]string{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The PR updates the `cmd/bom` go packege to replace `github.com/pkg/errors dependency` with native error wrapping

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes-sigs/bom/issues/114

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
