### PR TITLE
pkg/query: replace github.com/pkg/errors dependency with native error wrapping

### DIFF
--- a/pkg/query/engine.go
+++ b/pkg/query/engine.go
@@ -17,9 +17,9 @@ limitations under the License.
 package query
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/bom/pkg/spdx"
 )
 
@@ -39,7 +39,7 @@ func New() *Engine {
 func (e *Engine) Open(path string) error {
 	doc, err := spdx.OpenDoc(path)
 	if err != nil {
-		return errors.Wrap(err, "opening doc")
+		return fmt.Errorf("opening doc: %w", err)
 	}
 	e.Document = doc
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The PR updates the `pkg/query` go packege to replace `github.com/pkg/errors dependency` with native error wrapping

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes-sigs/bom/issues/114

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
