### PR TITLE
Add dir verification support via `bom validate -d`

### DIFF
--- a/pkg/spdx/parser.go
+++ b/pkg/spdx/parser.go
@@ -317,7 +317,7 @@ func OpenDoc(path string) (doc *Document, err error) {
 		case "LicenseListVersion":
 			doc.LicenseListVersion = value
 		default:
-			logrus.Warnf("Unknown tag: %s", tag)
+			logrus.Debugf("Unknown tag: %s", tag)
 		}
 		i++
 	}


### PR DESCRIPTION

#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We now can validate whole directories rather than just a set of files.
This can be used for example like this, if we assume that `cri-o`
contains the full tarball content (the package).

```
> bom validate -e cri-o.amd64.770ae3f4be46ba4fc731836eb274f365c6e9fd85.tar.gz.spdx -d cri-o

+-----------------------------------+-------+-----------------------------+----------------+
|             FILENAME              | VALID |           MESSAGE           | INVALID HASHES |
+-----------------------------------+-------+-----------------------------+----------------+
| LICENSE                           | OK    | File validated successfully | -              |
| Makefile                          | OK    | File validated successfully | -              |
| README.md                         | OK    | File validated successfully | -              |
| bin/conmon                        | OK    | File validated successfully | -              |
| bin/crictl                        | OK    | File validated successfully | -              |
| bin/crio                          | OK    | File validated successfully | -              |
| bin/crio-status                   | OK    | File validated successfully | -              |
| bin/crun                          | OK    | File validated successfully | -              |
| bin/pinns                         | OK    | File validated successfully | -              |
| bin/runc                          | OK    | File validated successfully | -              |
| cni-plugins/bandwidth             | OK    | File validated successfully | -              |
| cni-plugins/bridge                | OK    | File validated successfully | -              |
| cni-plugins/dhcp                  | OK    | File validated successfully | -              |
| cni-plugins/firewall              | OK    | File validated successfully | -              |
| cni-plugins/host-device           | OK    | File validated successfully | -              |
| cni-plugins/host-local            | OK    | File validated successfully | -              |
| cni-plugins/ipvlan                | OK    | File validated successfully | -              |
| cni-plugins/loopback              | OK    | File validated successfully | -              |
| cni-plugins/macvlan               | OK    | File validated successfully | -              |
| cni-plugins/portmap               | OK    | File validated successfully | -              |
| cni-plugins/ptp                   | OK    | File validated successfully | -              |
| cni-plugins/sbr                   | OK    | File validated successfully | -              |
| cni-plugins/static                | OK    | File validated successfully | -              |
| cni-plugins/tuning                | OK    | File validated successfully | -              |
| cni-plugins/vlan                  | OK    | File validated successfully | -              |
| cni-plugins/vrf                   | OK    | File validated successfully | -              |
| completions/bash/crio             | OK    | File validated successfully | -              |
| completions/bash/crio-status      | OK    | File validated successfully | -              |
| completions/fish/crio-status.fish | OK    | File validated successfully | -              |
| completions/fish/crio.fish        | OK    | File validated successfully | -              |
| completions/zsh/_crio             | OK    | File validated successfully | -              |
| completions/zsh/_crio-status      | OK    | File validated successfully | -              |
| contrib/10-crio-bridge.conf       | OK    | File validated successfully | -              |
| contrib/crio.service              | OK    | File validated successfully | -              |
| contrib/policy.json               | OK    | File validated successfully | -              |
| etc/10-crun.conf                  | OK    | File validated successfully | -              |
| etc/crictl.yaml                   | OK    | File validated successfully | -              |
| etc/crio-umount.conf              | OK    | File validated successfully | -              |
| etc/crio.conf                     | OK    | File validated successfully | -              |
| install                           | OK    | File validated successfully | -              |
| man/crio-status.8                 | OK    | File validated successfully | -              |
| man/crio.8                        | OK    | File validated successfully | -              |
| man/crio.conf.5                   | OK    | File validated successfully | -              |
| man/crio.conf.d.5                 | OK    | File validated successfully | -              |
+-----------------------------------+-------+-----------------------------+----------------+
```

The exit code behavior has been changed to print the table in any case.
This makes it easier to find which file failed the validation. We now
also collect the files from all packages of the spdx document, not only
the root of it.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
cc @kubernetes-sigs/release-engineering
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added support for verifying whole directories via `bom validate -d`.
```
