### PR TITLE
Add External Document Ref to json types

### DIFF
--- a/pkg/spdx/json/v2.2.2/types.go
+++ b/pkg/spdx/json/v2.2.2/types.go
@@ -22,16 +22,17 @@ const (
 )
 
 type Document struct {
-	ID                string         `json:"SPDXID"`
-	Name              string         `json:"name"`
-	Version           string         `json:"spdxVersion"`
-	CreationInfo      CreationInfo   `json:"creationInfo"`
-	DataLicense       string         `json:"dataLicense"`
-	Namespace         string         `json:"documentNamespace"`
-	DocumentDescribes []string       `json:"documentDescribes"`
-	Files             []File         `json:"files,omitempty"`
-	Packages          []Package      `json:"packages"`
-	Relationships     []Relationship `json:"relationships"`
+	ID                   string                `json:"SPDXID"`
+	Name                 string                `json:"name"`
+	Version              string                `json:"spdxVersion"`
+	CreationInfo         CreationInfo          `json:"creationInfo"`
+	DataLicense          string                `json:"dataLicense"`
+	Namespace            string                `json:"documentNamespace"`
+	DocumentDescribes    []string              `json:"documentDescribes"`
+	Files                []File                `json:"files,omitempty"`
+	Packages             []Package             `json:"packages"`
+	Relationships        []Relationship        `json:"relationships"`
+	ExternalDocumentRefs []ExternalDocumentRef `json:"externalDocumentRefs"`
 }
 
 type CreationInfo struct {
@@ -85,6 +86,12 @@ type ExternalRef struct {
 	Category string `json:"referenceCategory"`
 	Locator  string `json:"referenceLocator"`
 	Type     string `json:"referenceType"`
+}
+
+type ExternalDocumentRef struct {
+	Checksum           Checksum `json:"checksum"`
+	ExternalDocumentID string   `json:"externalDocumentId"`
+	SPDXDocument       string   `json:"spdxDocument"`
 }
 
 type Relationship struct {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

`externalDocumentRefs` were missing from the document type. This commit adds
support for it and the corresponding struct for the references.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `externalDocumentRefs` to the json types
```
