### PR TITLE
Remove feedback from docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,6 @@ on:
       - "docs/**"
     branches:
       - main  # Set a branch to deploy
-  pull_request:
 
 jobs:
   deploy:

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -140,7 +140,7 @@ footer_about_disable = false
 # If you want this feature, but occasionally need to remove the "Feedback" section from a single page,
 # add "hide_feedback: true" to the page's front matter.
 [params.ui.feedback]
-enable = true
+enable = false
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
 yes = 'Glad to hear it! Please <a href="https://github.com/kubernetes-sigs/bom/issues/new">tell us how we can improve</a>.'
 no = 'Sorry to hear that. Please <a href="https://github.com/kubernetes-sigs/bom/issues/new">tell us how we can improve</a>.'


### PR DESCRIPTION
Feedback only asks to open an issue, and which is too much for the simple pages we are showing