### PR TITLE
Don't concatenate name and version in os packages

### DIFF
--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -923,7 +923,7 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 		if i == layerNum && osPackageData != nil {
 			for i := range *osPackageData {
 				ospk := NewPackage()
-				ospk.Name = (*osPackageData)[i].Package + "-" + (*osPackageData)[i].Version
+				ospk.Name = (*osPackageData)[i].Package
 				ospk.Version = (*osPackageData)[i].Version
 				ospk.HomePage = (*osPackageData)[i].HomePage
 				if (*osPackageData)[i].MaintainerName != "" {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR changes the way bom adds package names, until now we were concatenating version and name in the package name.

This is not correct, now bom will only add the name in the name field and the package version is still contained in the SBOM version field.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

/kind bug

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where Debian packages were listed in the SBOM with the version appended, now `Name` only has the name as expected
```
