### PR TITLE
Disable local cache lookup, favor parallel download

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,13 +21,9 @@ require (
 )
 
 require (
-	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/andybalholm/brotli v1.0.3 // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,7 +51,6 @@ contrib.go.opencensus.io/exporter/stackdriver v0.13.4/go.mod h1:aXENhDJ1Y4lIg4EU
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Antonboom/errname v0.1.5/go.mod h1:DugbBstvPFQbv/5uLcRRzfrNqKE9tVdVCqWCLp6Cifo=
 github.com/Antonboom/nilnil v0.1.0/go.mod h1:PhHLvRPSghY5Y7mX4TW+BHZQYo1A8flE5H20D3IPZBo=
-github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -63,8 +62,6 @@ github.com/Masterminds/sprig v2.15.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
-github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
-github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
@@ -159,10 +156,6 @@ github.com/docker/docker v20.10.16+incompatible h1:2Db6ZR/+FUR3hqPMwnogOPHFn405c
 github.com/docker/docker v20.10.16+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.4 h1:axCks+yV+2MR3/kZhAmy07yC56WZ2Pwu/fKWtKuZB0o=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
-github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
-github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
-github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
-github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 h1:iFaUwBSo5Svw6L7HYpRu/0lE3e0BaElwnNO1qkNQxBY=
 github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj60/X5sZFNxpG4HBPDHVqxNm4DfnCKgrbZOT+s=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
@@ -236,7 +229,6 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -530,14 +522,12 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/moricho/tparallel v0.2.1/go.mod h1:fXEIZxG2vdfl0ZF8b42f5a78EhjjD5mX8qUplsoSU4k=
-github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/mozilla/scribe v0.0.0-20180711195314-fb71baf557c1/go.mod h1:FIczTrinKo8VaLxe6PWTPEXRXDIHz2QAwiaBaP5/4a8=
 github.com/mozilla/tls-observatory v0.0.0-20210609171429-7bc42856d2e5/go.mod h1:FUqVoUPHSEdDR0MnFM3Dh8AU0pZHLXUD127SAJGER/s=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -1024,7 +1014,6 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -579,7 +579,7 @@ func (di *spdxDefaultImplementation) GetDirectoryLicense(
 }
 
 // purlFromImage builds a purl from an image reference
-func (*spdxDefaultImplementation) purlFromImage(img ImageReferenceInfo) string {
+func (*spdxDefaultImplementation) purlFromImage(img *ImageReferenceInfo) string {
 	// OCI type urls don't have a namespace ref:
 	// https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#oci
 
@@ -653,7 +653,7 @@ func (di *spdxDefaultImplementation) ImageRefToPackage(ref string, opts *Options
 		if err != nil {
 			return nil, fmt.Errorf("building package from single image: %w", err)
 		}
-		packageurl := di.purlFromImage(imgs[0])
+		packageurl := di.purlFromImage(&imgs[0])
 		if packageurl != "" {
 			p.ExternalRefs = append(p.ExternalRefs, ExternalRef{
 				Category: "PACKAGE-MANAGER",
@@ -678,7 +678,7 @@ func (di *spdxDefaultImplementation) ImageRefToPackage(ref string, opts *Options
 	}
 
 	// Now, cycle each image in the index and generate a package from it
-	for _, img := range imgs {
+	for i, img := range imgs {
 		subpkg, err := di.PackageFromImageTarball(opts, img.Archive)
 		if err != nil {
 			return nil, fmt.Errorf("adding image variant package: %w", err)
@@ -694,7 +694,7 @@ func (di *spdxDefaultImplementation) ImageRefToPackage(ref string, opts *Options
 			subpkg.Name = img.Reference
 		}
 
-		packageurl := di.purlFromImage(img)
+		packageurl := di.purlFromImage(&imgs[i])
 		if packageurl != "" {
 			subpkg.ExternalRefs = append(subpkg.ExternalRefs, ExternalRef{
 				Category: "PACKAGE-MANAGER",
@@ -718,7 +718,7 @@ func (di *spdxDefaultImplementation) ImageRefToPackage(ref string, opts *Options
 	}
 
 	// Add a the topmost package purl
-	packageurl := di.purlFromImage(ImageReferenceInfo{Reference: ref})
+	packageurl := di.purlFromImage(&ImageReferenceInfo{Reference: ref})
 	if packageurl != "" {
 		pkg.ExternalRefs = append(pkg.ExternalRefs, ExternalRef{
 			Category: "PACKAGE-MANAGER",

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -344,11 +344,15 @@ func (di *spdxDefaultImplementation) PullImagesToArchive(
 
 			d, ok := ref.(name.Digest)
 			if !ok {
-				t.Done(fmt.Errorf("reference is not a tag or digest"))
+				t.Done(errors.New("reference is not a tag or digest"))
 				return
 			}
 
 			p := strings.Split(d.DigestStr(), ":")
+			if len(p) < 2 {
+				t.Done(fmt.Errorf("unable to parse digest string %s", d.DigestStr()))
+				return
+			}
 			tarPath := filepath.Join(path, p[1]+".tar")
 
 			logrus.Infof("Downloading %s from remote registry to %s", r.Digest, tarPath)
@@ -356,7 +360,7 @@ func (di *spdxDefaultImplementation) PullImagesToArchive(
 			// Download image from remote
 			img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 			if err != nil {
-				t.Done(fmt.Errorf("getting image: %w", err))
+				t.Done(fmt.Errorf("getting image from remote: %w", err))
 				return
 			}
 

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -218,29 +218,6 @@ func getImageReferences(referenceString string) ([]struct {
 		OS     string
 	}{}
 
-	img, err := daemon.Image(ref)
-	if err != nil && (!strings.Contains(err.Error(), "Error: No such image") &&
-		!strings.Contains(err.Error(), "Cannot connect to the Docker daemon at")) {
-		return nil, fmt.Errorf("could not get image reference %s: %s", referenceString, err)
-	}
-
-	if img != nil {
-		if size, err := img.Size(); err == nil && size > 0 {
-			tag, ok := ref.(name.Tag)
-			if !ok {
-				return nil, fmt.Errorf("could not cast tag from reference %s: %w", referenceString, err)
-			}
-
-			logrus.Infof("Adding image tag %s from reference", referenceString)
-			return append(images, struct {
-				Digest string
-				Tag    string
-				Arch   string
-				OS     string
-			}{Tag: tag.String()}), nil
-		}
-	}
-
 	descr, err := remote.Get(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
 		return nil, fmt.Errorf("fetching remote descriptor: %w", err)
@@ -445,7 +422,7 @@ func (di *spdxDefaultImplementation) PullImagesToArchive(
 			return nil, fmt.Errorf("parsing reference %s: %w", referenceString, err)
 		}
 
-		logrus.Infof("Trying to downloat it %s from remote", refData.Digest)
+		logrus.Infof("Trying to download %s from remote", refData.Digest)
 		// Get the reference image
 		img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 		if err != nil {

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -336,9 +336,9 @@ func (di *spdxDefaultImplementation) PullImagesToArchive(
 
 	for _, refData := range references {
 		go func(r ImageReferenceInfo) {
-			ref, err := name.ParseReference(refData.Digest)
+			ref, err := name.ParseReference(r.Digest)
 			if err != nil {
-				t.Done(fmt.Errorf("parsing reference %s: %w", referenceString, err))
+				t.Done(fmt.Errorf("parsing reference %s: %w", r.Digest, err))
 				return
 			}
 
@@ -351,7 +351,7 @@ func (di *spdxDefaultImplementation) PullImagesToArchive(
 			p := strings.Split(d.DigestStr(), ":")
 			tarPath := filepath.Join(path, p[1]+".tar")
 
-			logrus.Infof("Downloading %s from remote registry to %s", refData.Digest, tarPath)
+			logrus.Infof("Downloading %s from remote registry to %s", r.Digest, tarPath)
 
 			// Download image from remote
 			img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
@@ -369,9 +369,9 @@ func (di *spdxDefaultImplementation) PullImagesToArchive(
 				t.Done(fmt.Errorf("writing image to disk: %w", err))
 				return
 			}
-			refData.Archive = tarPath
+			r.Archive = tarPath
 			mtx.Lock()
-			images = append(images, refData)
+			images = append(images, r)
 			mtx.Unlock()
 			t.Done(nil)
 		}(refData)

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -234,7 +234,7 @@ func (spdx *SPDX) ExtractTarballTmp(tarPath string) (tmpDir string, err error) {
 	return spdx.impl.ExtractTarballTmp(tarPath)
 }
 
-// PullImagesToArchive
+// PullImagesToArchive downloads all the images found from a reference to disk
 func (spdx *SPDX) PullImagesToArchive(reference, path string) ([]ImageReferenceInfo, error) {
 	return spdx.impl.PullImagesToArchive(reference, path)
 }

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -64,6 +64,15 @@ type SPDX struct {
 	options *Options
 }
 
+// ImageReferenceInfo is a type to move information about a container image reference
+type ImageReferenceInfo struct {
+	Digest    string
+	Reference string
+	Archive   string
+	Arch      string
+	OS        string
+}
+
 func NewSPDX() *SPDX {
 	return &SPDX{
 		impl:    &spdxDefaultImplementation{},
@@ -226,13 +235,7 @@ func (spdx *SPDX) ExtractTarballTmp(tarPath string) (tmpDir string, err error) {
 }
 
 // PullImagesToArchive
-func (spdx *SPDX) PullImagesToArchive(reference, path string) ([]struct {
-	Reference string
-	Archive   string
-	Arch      string
-	OS        string
-}, error,
-) {
+func (spdx *SPDX) PullImagesToArchive(reference, path string) ([]ImageReferenceInfo, error) {
 	return spdx.impl.PullImagesToArchive(reference, path)
 }
 

--- a/pkg/spdx/spdxfakes/fake_spdx_implementation.go
+++ b/pkg/spdx/spdxfakes/fake_spdx_implementation.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
-
 	"sigs.k8s.io/bom/pkg/license"
 	"sigs.k8s.io/bom/pkg/spdx"
 )
@@ -191,33 +190,18 @@ type FakeSpdxImplementation struct {
 		result1 *spdx.Package
 		result2 error
 	}
-	PullImagesToArchiveStub func(string, string) ([]struct {
-		Reference string
-		Archive   string
-		Arch      string
-		OS        string
-	}, error)
+	PullImagesToArchiveStub        func(string, string) ([]spdx.ImageReferenceInfo, error)
 	pullImagesToArchiveMutex       sync.RWMutex
 	pullImagesToArchiveArgsForCall []struct {
 		arg1 string
 		arg2 string
 	}
 	pullImagesToArchiveReturns struct {
-		result1 []struct {
-			Reference string
-			Archive   string
-			Arch      string
-			OS        string
-		}
+		result1 []spdx.ImageReferenceInfo
 		result2 error
 	}
 	pullImagesToArchiveReturnsOnCall map[int]struct {
-		result1 []struct {
-			Reference string
-			Archive   string
-			Arch      string
-			OS        string
-		}
+		result1 []spdx.ImageReferenceInfo
 		result2 error
 	}
 	ReadArchiveManifestStub        func(string) (*spdx.ArchiveManifest, error)
@@ -1026,12 +1010,7 @@ func (fake *FakeSpdxImplementation) PackageFromTarballReturnsOnCall(i int, resul
 	}{result1, result2}
 }
 
-func (fake *FakeSpdxImplementation) PullImagesToArchive(arg1 string, arg2 string) ([]struct {
-	Reference string
-	Archive   string
-	Arch      string
-	OS        string
-}, error) {
+func (fake *FakeSpdxImplementation) PullImagesToArchive(arg1 string, arg2 string) ([]spdx.ImageReferenceInfo, error) {
 	fake.pullImagesToArchiveMutex.Lock()
 	ret, specificReturn := fake.pullImagesToArchiveReturnsOnCall[len(fake.pullImagesToArchiveArgsForCall)]
 	fake.pullImagesToArchiveArgsForCall = append(fake.pullImagesToArchiveArgsForCall, struct {
@@ -1057,12 +1036,7 @@ func (fake *FakeSpdxImplementation) PullImagesToArchiveCallCount() int {
 	return len(fake.pullImagesToArchiveArgsForCall)
 }
 
-func (fake *FakeSpdxImplementation) PullImagesToArchiveCalls(stub func(string, string) ([]struct {
-	Reference string
-	Archive   string
-	Arch      string
-	OS        string
-}, error)) {
+func (fake *FakeSpdxImplementation) PullImagesToArchiveCalls(stub func(string, string) ([]spdx.ImageReferenceInfo, error)) {
 	fake.pullImagesToArchiveMutex.Lock()
 	defer fake.pullImagesToArchiveMutex.Unlock()
 	fake.PullImagesToArchiveStub = stub
@@ -1075,53 +1049,28 @@ func (fake *FakeSpdxImplementation) PullImagesToArchiveArgsForCall(i int) (strin
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeSpdxImplementation) PullImagesToArchiveReturns(result1 []struct {
-	Reference string
-	Archive   string
-	Arch      string
-	OS        string
-}, result2 error) {
+func (fake *FakeSpdxImplementation) PullImagesToArchiveReturns(result1 []spdx.ImageReferenceInfo, result2 error) {
 	fake.pullImagesToArchiveMutex.Lock()
 	defer fake.pullImagesToArchiveMutex.Unlock()
 	fake.PullImagesToArchiveStub = nil
 	fake.pullImagesToArchiveReturns = struct {
-		result1 []struct {
-			Reference string
-			Archive   string
-			Arch      string
-			OS        string
-		}
+		result1 []spdx.ImageReferenceInfo
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeSpdxImplementation) PullImagesToArchiveReturnsOnCall(i int, result1 []struct {
-	Reference string
-	Archive   string
-	Arch      string
-	OS        string
-}, result2 error) {
+func (fake *FakeSpdxImplementation) PullImagesToArchiveReturnsOnCall(i int, result1 []spdx.ImageReferenceInfo, result2 error) {
 	fake.pullImagesToArchiveMutex.Lock()
 	defer fake.pullImagesToArchiveMutex.Unlock()
 	fake.PullImagesToArchiveStub = nil
 	if fake.pullImagesToArchiveReturnsOnCall == nil {
 		fake.pullImagesToArchiveReturnsOnCall = make(map[int]struct {
-			result1 []struct {
-				Reference string
-				Archive   string
-				Arch      string
-				OS        string
-			}
+			result1 []spdx.ImageReferenceInfo
 			result2 error
 		})
 	}
 	fake.pullImagesToArchiveReturnsOnCall[i] = struct {
-		result1 []struct {
-			Reference string
-			Archive   string
-			Arch      string
-			OS        string
-		}
+		result1 []spdx.ImageReferenceInfo
 		result2 error
 	}{result1, result2}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR disables the local daemon lookup of container images to fix #134. 

When passing a reference to a multiarch image to the local docker daemon, the reference gets transalated to the local arch image, generating an SBOM only for the image corresponding to the local architecture. 

This PR reverts the local daemon change as apparently there is no way to get the docker daemon to return the correct reference (to the image index ) to GGCR.

In order to improve image download times the blob downloads to local tarballs are now parallelized which should at least provide some speed gains.

#### Which issue(s) this PR fixes:

Fixes #134

#### Special notes for your reviewer:

/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
- Looking for precached images in the local daemon is now removed as it broke multiarch image SBOMs
- Image downloading is now done in parallel. This should provide some speed gains in some high bandwidth settings
```
