### PR TITLE
Add package url external ref in json format too

### DIFF
--- a/pkg/serialize/serialize.go
+++ b/pkg/serialize/serialize.go
@@ -139,6 +139,12 @@ func (json *JSON) buildJSONPackage(p *spdx.Package) (jsonPackage v222.Package, e
 		return jsonPackage, fmt.Errorf("computing license list from files: %w", err)
 	}
 
+	externalRefs := make([]v222.ExternalRef, len(p.ExternalRefs))
+	for i, ref := range p.ExternalRefs {
+		externalRefs[i].Category = ref.Category
+		externalRefs[i].Locator = ref.Locator
+		externalRefs[i].Type = ref.Type
+	}
 	jsonPackage = v222.Package{
 		ID:                   p.SPDXID(),
 		Name:                 p.Name,
@@ -151,7 +157,7 @@ func (json *JSON) buildJSONPackage(p *spdx.Package) (jsonPackage v222.Package, e
 		CopyrightText:        p.CopyrightText,
 		HasFiles:             []string{},
 		Checksums:            []v222.Checksum{},
-		ExternalRefs:         []v222.ExternalRef{},
+		ExternalRefs:         externalRefs,
 		VerificationCode: v222.PackageVerificationCode{
 			Value: p.VerificationCode,
 		},


### PR DESCRIPTION
When the BOM was to be generated in SPDX JSON format, the external reference for PURL was missing. This PR fixes that.

Eg, a package node before PR would look like
```javascript
  {
      "SPDXID": "SPDXRef-Package-gomod-github.com-gogo-protobuf-v1.3.2",
      "name": "github.com/gogo/protobuf",
      "versionInfo": "v1.3.2",
      "filesAnalyzed": false,
      "licenseDeclared": "NOASSERTION",
      "licenseConcluded": "BSD-3-Clause",
      "downloadLocation": "https://proxy.golang.org/github.com/gogo/protobuf/@v/v1.3.2.zip",
      "copyrightText": "Copyright (c) 2013, The GoGo Authors. All rights reserved.\n\nProtocol Buffers for Go with Gadgets\n\nGo support for Protocol Buffers - Google's data interchange format\n\nCopyright 2010 The Go Authors.  All rights reserved.\nhttps://github.com/golang/protobuf\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n    * Redistributions of source code must retain the above copyright\nnotice, this list of conditions and the following disclaimer.\n    * Redistributions in binary form must reproduce the above\ncopyright notice, this list of conditions and the following disclaimer\nin the documentation and/or other materials provided with the\ndistribution.\n    * Neither the name of Google Inc. nor the names of its\ncontributors may be used to endorse or promote products derived from\nthis software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\nOWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\n",
      "checksums": [],
      "packageVerificationCode": {
        "packageVerificationCodeValue": ""
      }
    }
```

After the PR it looks like:
```javascript
 {
      "SPDXID": "SPDXRef-Package-gomod-github.com-gogo-protobuf-v1.3.2",
      "name": "github.com/gogo/protobuf",
      "versionInfo": "v1.3.2",
      "filesAnalyzed": false,
      "licenseDeclared": "NOASSERTION",
      "licenseConcluded": "BSD-3-Clause",
      "downloadLocation": "https://proxy.golang.org/github.com/gogo/protobuf/@v/v1.3.2.zip",
      "copyrightText": "Copyright (c) 2013, The GoGo Authors. All rights reserved.\n\nProtocol Buffers for Go with Gadgets\n\nGo support for Protocol Buffers - Google's data interchange format\n\nCopyright 2010 The Go Authors.  All rights reserved.\nhttps://github.com/golang/protobuf\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n    * Redistributions of source code must retain the above copyright\nnotice, this list of conditions and the following disclaimer.\n    * Redistributions in binary form must reproduce the above\ncopyright notice, this list of conditions and the following disclaimer\nin the documentation and/or other materials provided with the\ndistribution.\n    * Neither the name of Google Inc. nor the names of its\ncontributors may be used to endorse or promote products derived from\nthis software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\nOWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\n",
      "checksums": [],
      "externalRefs": [
        {
          "referenceCategory": "PACKAGE-MANAGER",
          "referenceLocator": "pkg:golang/github.com/protobuf@v1.3.2",
          "referenceType": "purl"
        }
      ],
      "packageVerificationCode": {
        "packageVerificationCodeValue": ""
      }
    }
```
