### PR TITLE
Update image SBOMs to current practices

### DIFF
--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -641,9 +641,16 @@ func (*spdxDefaultImplementation) purlFromImage(img *ImageReferenceInfo) string 
 	if img.Arch != "" {
 		mm["arch"] = img.Arch
 	}
+	if img.OS != "" {
+		mm["os"] = img.OS
+	}
 	if tag, ok := imageReference.(name.Tag); ok {
 		mm["tag"] = tag.String()
 	}
+	if img.MediaType != "" {
+		mm["mediaType"] = img.MediaType
+	}
+
 	packageurl := purl.NewPackageURL(
 		purl.TypeOCI, "", imageName, digest,
 		purl.QualifiersFromMap(mm), "",

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -218,7 +218,8 @@ func refInfoFromIndex(descr *remote.Descriptor) (refinfo *ImageReferenceInfo, er
 	refinfo = &ImageReferenceInfo{Images: []ImageReferenceInfo{}}
 	logrus.Infof("Reference %s points to an index", descr.Ref.String())
 
-	if _, ok := descr.Ref.(name.Tag); !ok {
+	tag := descr.Ref.Context().Tag(descr.Ref.String())
+	if tag.String() == "" {
 		return nil, fmt.Errorf("cannot build tag from reference %s", descr.Ref.String())
 	}
 
@@ -234,7 +235,7 @@ func refInfoFromIndex(descr *remote.Descriptor) (refinfo *ImageReferenceInfo, er
 	}
 
 	// If we could not turn the reference to digest then we synthesize one
-	dig, err := fullDigest(descr.Ref.(name.Tag), indexDigest)
+	dig, err := fullDigest(tag, indexDigest)
 	if err != nil {
 		return nil, fmt.Errorf("building single image digest: %w", err)
 	}
@@ -278,7 +279,8 @@ func refInfoFromImage(descr *remote.Descriptor) (refinfo *ImageReferenceInfo, er
 	refinfo = &ImageReferenceInfo{}
 	logrus.Infof("Reference %s points to a single image", descr.Ref.String())
 
-	if _, ok := descr.Ref.(name.Tag); !ok {
+	tag := descr.Ref.Context().Tag(descr.Ref.String())
+	if tag.String() == "" {
 		return nil, fmt.Errorf("cannot build tag from reference %s", descr.Ref.String())
 	}
 
@@ -294,7 +296,7 @@ func refInfoFromImage(descr *remote.Descriptor) (refinfo *ImageReferenceInfo, er
 	}
 
 	// If we could not turn the reference to digest then we synthesize one
-	dig, err := fullDigest(descr.Ref.(name.Tag), imageDigest)
+	dig, err := fullDigest(tag, imageDigest)
 	if err != nil {
 		return nil, fmt.Errorf("building single image digest: %w", err)
 	}
@@ -408,7 +410,7 @@ func createReferenceArchive(digest, path string) (tarPath string, err error) {
 
 	d, ok := ref.(name.Digest)
 	if !ok {
-		return "", errors.New("reference is not a tag or digest")
+		return "", errors.New("reference is not a digest")
 	}
 
 	p := strings.Split(d.DigestStr(), ":")

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -46,6 +46,7 @@ import (
 
 	"sigs.k8s.io/bom/pkg/license"
 	"sigs.k8s.io/bom/pkg/osinfo"
+	"sigs.k8s.io/release-utils/hash"
 	"sigs.k8s.io/release-utils/util"
 )
 
@@ -841,6 +842,12 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 		if err != nil {
 			return nil, fmt.Errorf("building package from layer: %w", err)
 		}
+
+		h, err := hash.SHA256ForFile(filepath.Join(tarOpts.ExtractDir, layerFile))
+		if err != nil {
+			return nil, fmt.Errorf("hashing layer tarball: %w", err)
+		}
+		pkg.Name = "sha256:" + h
 
 		// Regenerate the BuildID to avoid clashes when handling multiple
 		// images at the same time.

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -46,7 +46,6 @@ import (
 
 	"sigs.k8s.io/bom/pkg/license"
 	"sigs.k8s.io/bom/pkg/osinfo"
-	"sigs.k8s.io/release-utils/hash"
 	"sigs.k8s.io/release-utils/util"
 )
 
@@ -843,15 +842,11 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 			return nil, fmt.Errorf("building package from layer: %w", err)
 		}
 
-		h, err := hash.SHA256ForFile(filepath.Join(tarOpts.ExtractDir, layerFile))
-		if err != nil {
-			return nil, fmt.Errorf("hashing layer tarball: %w", err)
-		}
-		pkg.Name = "sha256:" + h
+		pkg.Name = "sha256:" + pkg.Checksum["SHA256"]
 
 		// Regenerate the BuildID to avoid clashes when handling multiple
 		// images at the same time.
-		pkg.BuildID(manifest.RepoTags[0], layerFile)
+		pkg.BuildID(manifest.RepoTags[0], pkg.Name)
 
 		// If the option is enabled, scan the container layers
 		if spdxOpts.AnalyzeLayers {

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -237,7 +237,7 @@ func (spdx *SPDX) ExtractTarballTmp(tarPath string) (tmpDir string, err error) {
 }
 
 // PullImagesToArchive downloads all the images found from a reference to disk
-func (spdx *SPDX) PullImagesToArchive(reference, path string) ([]ImageReferenceInfo, error) {
+func (spdx *SPDX) PullImagesToArchive(reference, path string) (*ImageReferenceInfo, error) {
 	return spdx.impl.PullImagesToArchive(reference, path)
 }
 

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -71,6 +71,8 @@ type ImageReferenceInfo struct {
 	Archive   string
 	Arch      string
 	OS        string
+	MediaType string
+	Images    []ImageReferenceInfo
 }
 
 func NewSPDX() *SPDX {

--- a/pkg/spdx/spdx_unit_test.go
+++ b/pkg/spdx/spdx_unit_test.go
@@ -334,7 +334,11 @@ func TestPullImagesToArchive(t *testing.T) {
 	// The pause 1.0 image is a single image
 	images, err := impl.PullImagesToArchive("registry.k8s.io/pause:1.0", dir)
 	require.NoError(t, err)
-	require.Len(t, images, 1)
+	require.Equal(t, "registry.k8s.io/pause@sha256:a78c2d6208eff9b672de43f880093100050983047b7b0afe0217d3656e1b0d5f", images.Digest)
+	require.Equal(t, "amd64", images.Arch)
+	require.Equal(t, "linux", images.OS)
+	require.Equal(t, "application/vnd.docker.distribution.manifest.v2+json", images.MediaType)
+	require.Len(t, images.Images, 0) // This is an image, so no child images
 	require.FileExists(t, filepath.Join(dir, "a78c2d6208eff9b672de43f880093100050983047b7b0afe0217d3656e1b0d5f.tar"))
 
 	foundFiles := []string{}
@@ -470,13 +474,13 @@ func TestPurlFromImage(t *testing.T) {
 	}{
 		{
 			ImageReferenceInfo{
-				Digest:    "sha256:c183d71d4173c3148b73d17aba0f37c83ca8291d1f303d74a3fac4f5e1d01f57",
+				Digest:    "image@sha256:c183d71d4173c3148b73d17aba0f37c83ca8291d1f303d74a3fac4f5e1d01f57",
 				Reference: "",
 				Archive:   "",
 				Arch:      "",
 				OS:        "",
 			},
-			"pkg:oci/image@sha256:c183d71d4173c3148b73d17aba0f37c83ca8291d1f303d74a3fac4f5e1d01f57",
+			"pkg:oci/image@sha256:c183d71d4173c3148b73d17aba0f37c83ca8291d1f303d74a3fac4f5e1d01f57?repository_url=index.docker.io%2Flibrary",
 		},
 		{
 			ImageReferenceInfo{
@@ -486,7 +490,7 @@ func TestPurlFromImage(t *testing.T) {
 				Arch:      "amd64",
 				OS:        "darwin",
 			},
-			"pkg:oci/nginx@sha256:c183d71d4173c3148b73d17aba0f37c83ca8291d1f303d74a3fac4f5e1d01f57?arch=amd64&repository_url=index.docker.io%2Flibrary",
+			"pkg:oci/nginx@sha256:c183d71d4173c3148b73d17aba0f37c83ca8291d1f303d74a3fac4f5e1d01f57?arch=amd64&os=darwin&repository_url=index.docker.io%2Flibrary",
 		},
 	} {
 		impl := spdxDefaultImplementation{}

--- a/pkg/spdx/spdxfakes/fake_spdx_implementation.go
+++ b/pkg/spdx/spdxfakes/fake_spdx_implementation.go
@@ -190,18 +190,18 @@ type FakeSpdxImplementation struct {
 		result1 *spdx.Package
 		result2 error
 	}
-	PullImagesToArchiveStub        func(string, string) ([]spdx.ImageReferenceInfo, error)
+	PullImagesToArchiveStub        func(string, string) (*spdx.ImageReferenceInfo, error)
 	pullImagesToArchiveMutex       sync.RWMutex
 	pullImagesToArchiveArgsForCall []struct {
 		arg1 string
 		arg2 string
 	}
 	pullImagesToArchiveReturns struct {
-		result1 []spdx.ImageReferenceInfo
+		result1 *spdx.ImageReferenceInfo
 		result2 error
 	}
 	pullImagesToArchiveReturnsOnCall map[int]struct {
-		result1 []spdx.ImageReferenceInfo
+		result1 *spdx.ImageReferenceInfo
 		result2 error
 	}
 	ReadArchiveManifestStub        func(string) (*spdx.ArchiveManifest, error)
@@ -1010,7 +1010,7 @@ func (fake *FakeSpdxImplementation) PackageFromTarballReturnsOnCall(i int, resul
 	}{result1, result2}
 }
 
-func (fake *FakeSpdxImplementation) PullImagesToArchive(arg1 string, arg2 string) ([]spdx.ImageReferenceInfo, error) {
+func (fake *FakeSpdxImplementation) PullImagesToArchive(arg1 string, arg2 string) (*spdx.ImageReferenceInfo, error) {
 	fake.pullImagesToArchiveMutex.Lock()
 	ret, specificReturn := fake.pullImagesToArchiveReturnsOnCall[len(fake.pullImagesToArchiveArgsForCall)]
 	fake.pullImagesToArchiveArgsForCall = append(fake.pullImagesToArchiveArgsForCall, struct {
@@ -1036,7 +1036,7 @@ func (fake *FakeSpdxImplementation) PullImagesToArchiveCallCount() int {
 	return len(fake.pullImagesToArchiveArgsForCall)
 }
 
-func (fake *FakeSpdxImplementation) PullImagesToArchiveCalls(stub func(string, string) ([]spdx.ImageReferenceInfo, error)) {
+func (fake *FakeSpdxImplementation) PullImagesToArchiveCalls(stub func(string, string) (*spdx.ImageReferenceInfo, error)) {
 	fake.pullImagesToArchiveMutex.Lock()
 	defer fake.pullImagesToArchiveMutex.Unlock()
 	fake.PullImagesToArchiveStub = stub
@@ -1049,28 +1049,28 @@ func (fake *FakeSpdxImplementation) PullImagesToArchiveArgsForCall(i int) (strin
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeSpdxImplementation) PullImagesToArchiveReturns(result1 []spdx.ImageReferenceInfo, result2 error) {
+func (fake *FakeSpdxImplementation) PullImagesToArchiveReturns(result1 *spdx.ImageReferenceInfo, result2 error) {
 	fake.pullImagesToArchiveMutex.Lock()
 	defer fake.pullImagesToArchiveMutex.Unlock()
 	fake.PullImagesToArchiveStub = nil
 	fake.pullImagesToArchiveReturns = struct {
-		result1 []spdx.ImageReferenceInfo
+		result1 *spdx.ImageReferenceInfo
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeSpdxImplementation) PullImagesToArchiveReturnsOnCall(i int, result1 []spdx.ImageReferenceInfo, result2 error) {
+func (fake *FakeSpdxImplementation) PullImagesToArchiveReturnsOnCall(i int, result1 *spdx.ImageReferenceInfo, result2 error) {
 	fake.pullImagesToArchiveMutex.Lock()
 	defer fake.pullImagesToArchiveMutex.Unlock()
 	fake.PullImagesToArchiveStub = nil
 	if fake.pullImagesToArchiveReturnsOnCall == nil {
 		fake.pullImagesToArchiveReturnsOnCall = make(map[int]struct {
-			result1 []spdx.ImageReferenceInfo
+			result1 *spdx.ImageReferenceInfo
 			result2 error
 		})
 	}
 	fake.pullImagesToArchiveReturnsOnCall[i] = struct {
-		result1 []spdx.ImageReferenceInfo
+		result1 *spdx.ImageReferenceInfo
 		result2 error
 	}{result1, result2}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This pull request modifies the way we capture container images in SBOMs to make our output similar to that of other tools like tern and ko. It introduces two changes:

#### Package Names Now Reflect Digests

Before this change, our package names were based on the tags of images. We now use the digests, all the information about the image is still kept in the purl of the package, so the tag data is not lost:

![image](https://user-images.githubusercontent.com/3935899/179561083-eb599a2e-ab1b-4da4-b93a-2f0477cce001.png)


#### Image Archives Are Now Files (with OCI artifacts in them)

Image archives are now listed as tarfiles, instead of OCI artifacts. Since the archive is a tarball disconnected from a registry and its manifest is not there yet, we treat them as a file. The contents of those packages are the layers and those are they are still treated as packages, with their OCI purls.

#### Single image support

Generating an SBOM for a single arch image was broken. This PR also fixes that and now running something like:

```
bom generate -i registry.k8s.io/pause:1.0  | bom document outline -
```

Yields:

![image](https://user-images.githubusercontent.com/3935899/179567563-3c682336-9f4b-4f62-9acc-72133eb3879d.png)



#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

For a future iteration, I think we can make the SBOM outline more human friendly is we return to showing the tags in the output, which we can get from the purl.

(@saschagrunert this is the PR I was discussing during our meeting)
/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
- Image archives are treated as files now. The SBOM structure now consists of a package representing the tar, with the OCI artifacts inside.
- Package names now reflect container image digests instead of tags. This makes the `bom` SBOMs similar to what other tools are doing now
```
