### PR TITLE
SPDX json definition set to minor version

### DIFF
--- a/pkg/serialize/serialize.go
+++ b/pkg/serialize/serialize.go
@@ -24,7 +24,7 @@ import (
 
 	"sigs.k8s.io/bom/pkg/query"
 	"sigs.k8s.io/bom/pkg/spdx"
-	v222 "sigs.k8s.io/bom/pkg/spdx/json/v2.2.2"
+	v222 "sigs.k8s.io/bom/pkg/spdx/json/v2.2"
 )
 
 type Serializer interface {

--- a/pkg/spdx/json/v2.2/types.go
+++ b/pkg/spdx/json/v2.2/types.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v222
+package v22
 
 const (
 	NOASSERTION = "NOASSERTION"

--- a/pkg/spdx/parser.go
+++ b/pkg/spdx/parser.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	spdxJSON "sigs.k8s.io/bom/pkg/spdx/json/v2.2.2"
+	spdxJSON "sigs.k8s.io/bom/pkg/spdx/json/v2.2"
 )
 
 // Regexp to match the tag-value spdx expressions


### PR DESCRIPTION
Signed-off-by: Brandon Lum <lumjjb@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Simplifies the support with the release of newer SPDX versions so a new "patch" version does not need to be defined each time for the JSON struct.

#### Which issue(s) this PR fixes:

None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

None
-->

#### Special notes for your reviewer:

SPDX struct definitions are tied to minor versions, patch versions are only for documentation updates, so there's no need to specify structs to the level of the patch version :). 

#### Does this PR introduce a user-facing change?

No, unless there are uses of the `spdx/json` pkg
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Change SPDX json package name to remove patch semantic versioning
```
