### PR TITLE
Fix file type of compressed tars

### DIFF
--- a/pkg/spdx/file.go
+++ b/pkg/spdx/file.go
@@ -168,8 +168,8 @@ func getFileTypes(path string) []string {
 	case "mp3", "wav", "aif", "cda", "mid", "midi",
 		"mpa", "ogg", "wma", "wpl":
 		return []string{"AUDIO"}
-	case "zip", "tar", "tar.gz", "tar.bz2", "7z", "arj",
-		"deb", "pkg", "rar", "rpm", "z":
+	case "zip", "tar", "gz", "bz2", "7z", "arj",
+		"deb", "pkg", "rar", "rpm", "z", "cpio":
 		return []string{"ARCHIVE"}
 	default:
 		return []string{"OTHER"}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR fixes a bug where compressed tarballs did
not get their proper file type.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>


#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where `FileType` in compressed tars was not categorized as `ARCHIVE`
```
