### PR TITLE
Fix license package to work with latest license classiffier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
-	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/pkg/license/download.go
+++ b/pkg/license/download.go
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:gosec
 // SHA1 is the currently accepted hash algorithm for SPDX documents, used for
 // file integrity checks, NOT security.
 // Instances of G401 and G505 can be safely ignored in this file.
 //
 // ref: https://github.com/spdx/spdx-spec/issues/11
+//
+//nolint:gosec
 package license
 
 import (
@@ -140,7 +141,7 @@ func (ddi *DefaultDownloaderImpl) SetOptions(opts *DownloaderOptions) {
 // GetLicenses downloads the main json file listing all SPDX supported licenses
 func (ddi *DefaultDownloaderImpl) GetLicenses() (licenses *List, err error) {
 	// TODO: Cache licenselist
-	logrus.Info("Downloading main SPDX license data from " + LicenseDataURL)
+	logrus.Debugf("Downloading main SPDX license data from " + LicenseDataURL)
 
 	// Get the list of licenses
 	licensesJSON, err := http.NewAgent().Get(LicenseDataURL + LicenseListFilename)
@@ -249,13 +250,13 @@ func (ddi *DefaultDownloaderImpl) getLicenseFromURL(url string) (license *Licens
 
 	// If we still don't have json data, download it
 	if len(licenseJSON) == 0 {
-		logrus.Infof("Downloading license data from %s", url)
+		logrus.Debugf("Downloading license data from %s", url)
 		licenseJSON, err = http.NewAgent().Get(url)
 		if err != nil {
 			return nil, fmt.Errorf("getting %s: %w", url, err)
 		}
 
-		logrus.Infof("Downloaded %d bytes from %s", len(licenseJSON), url)
+		logrus.Debugf("Downloaded %d bytes from %s", len(licenseJSON), url)
 
 		if ddi.Options.EnableCache {
 			if err := ddi.cacheData(url, licenseJSON); err != nil {

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -102,8 +102,9 @@ func TestUSPDXWriteLicensesAsText(t *testing.T) {
 	// Check the call works:
 	require.Nil(t, spdx.WriteLicensesAsText(tempdir))
 
-	// Check we have one file
-	require.Nil(t, CheckFileExists(t, filepath.Join(tempdir, testLicenseID+".txt")))
+	// Check the files where written in the expected paths
+	require.Nil(t, CheckFileExists(t, filepath.Join(tempdir, "assets", testLicenseID, "license.txt")))
+	require.Nil(t, CheckFileExists(t, filepath.Join(tempdir, "assets", testLicenseID2, "license.txt")))
 }
 
 func TestUSPDXGetLicense(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR fixes the license package in bom to work with the latest prereleases of license classifier. The paths expected by the classifier changed, at first causing a panic fixed by @saschagrunert in https://github.com/google/licenseclassifier/pull/44 and now, we don't have the crash anymore but SBOMs are getting stuffed with junk as the traces are going to STDOUT:

```
go run ./cmd/bom/main.go generate --format=json ../chainguard/darkfiles/ 
INFO bom devel: Generating SPDX Bill of Materials 
INFO Processing directory ../chainguard/darkfiles/ 
INFO Loading license data from downloader         
INFO Downloading main SPDX license data from https://spdx.org/licenses/ 
INFO Sending GET request to https://spdx.org/licenses/licenses.json 
INFO Read data for 496 licenses. Downloading.     
INFO Downloaded 496 licenses                      
INFO Got 496 licenses from downloader             
INFO Writing license data to /tmp/spdx/downloadCache 
INFO Writing 496 SPDX licenses to /tmp/spdx/licenses 
Insufficient segment count for path: /0BSD.txt
Insufficient segment count for path: /AAL.txt
Insufficient segment count for path: /ADSL.txt
Insufficient segment count for path: /AFL-1.1.txt
Insufficient segment count for path: /AFL-1.2.txt
Insufficient segment count for path: /AFL-2.0.txt
Insufficient segment count for path: /AFL-2.1.txt
Insufficient segment count for path: /AFL-3.0.txt
...
```

Until now, we had avoided the path problem by avoiding to upgrade this dependency, but this change fixes the paths for good.

It also reworks the error handling in the writer function by moving it to an errorgroup as the migration to thew new native golang error wrapping introduced some funky handling.

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

/assign @saschagrunert 

#### Does this PR introduce a user-facing change?

```release-note
The license module in bom is now compatible with the latest `google/licenseclassifier` v2 prereleases.
```
