### PR TITLE
Fix file output with different format

### DIFF
--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -357,7 +357,9 @@ func generateBOM(opts *generateOptions) error {
 	if opts.outputFile == "" {
 		fmt.Println(markup)
 	} else {
-		os.WriteFile(opts.outputFile, []byte(markup), 0664)
+		if err := os.WriteFile(opts.outputFile, []byte(markup), 0o664); err != nil { //nolint:gosec // G306: Expect WriteFile
+			return fmt.Errorf("writing SBOM: %w", err)
+		}
 	}
 	// Export the SBOM as in-toto provenance
 	if opts.provenancePath != "" {

--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -343,22 +343,22 @@ func generateBOM(opts *generateOptions) error {
 		return fmt.Errorf("generating doc: %w", err)
 	}
 
-	if opts.outputFile == "" {
-		var renderer serialize.Serializer
-		if opts.format == "json" {
-			renderer = &serialize.JSON{}
-		} else {
-			renderer = &serialize.TagValue{}
-		}
-
-		markup, err := renderer.Serialize(doc)
-		if err != nil {
-			return fmt.Errorf("serializing document: %w", err)
-		}
-
-		fmt.Println(markup)
+	var renderer serialize.Serializer
+	if opts.format == "json" {
+		renderer = &serialize.JSON{}
+	} else {
+		renderer = &serialize.TagValue{}
 	}
 
+	markup, err := renderer.Serialize(doc)
+	if err != nil {
+		return fmt.Errorf("serializing document: %w", err)
+	}
+	if opts.outputFile == "" {
+		fmt.Println(markup)
+	} else {
+		os.WriteFile(opts.outputFile, []byte(markup), 0664)
+	}
 	// Export the SBOM as in-toto provenance
 	if opts.provenancePath != "" {
 		if err := doc.WriteProvenanceStatement(

--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -97,18 +97,6 @@ func (db *DocBuilder) Generate(genopts *DocGenerateOptions) (*Document, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating SPDX document: %w", err)
 	}
-
-	// If we have a specified output file, write it
-	if genopts.OutputFile == "" {
-		return doc, nil
-	}
-
-	if err := db.impl.WriteDoc(doc, genopts.OutputFile); err != nil {
-		return doc, fmt.Errorf(
-			"writing doc to %s: %w", genopts.OutputFile,
-			err,
-		)
-	}
 	return doc, nil
 }
 


### PR DESCRIPTION
Without this PR:
```bash
./bom generate ./   --format json -o bom.json
```

Would output standard SPDX bom in `bom.json`, completely disregarding the `--format` flag.

This PR fixes that. 