### PR TITLE
Allow specifying URLs in `document outline/query`

### DIFF
--- a/cmd/bom/cmd/document.go
+++ b/cmd/bom/cmd/document.go
@@ -108,7 +108,7 @@ bom will try to add useful information to the oultine but, if needed, you can
 set the --spdx-ids to only output the IDs of the entities.
 
 `,
-		Use:           "outline SPDX_FILE",
+		Use:           "outline SPDX_FILE|URL",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/bom/cmd/query.go
+++ b/cmd/bom/cmd/query.go
@@ -52,7 +52,7 @@ Example:
   bom document query sbom.spdx "depth:2 name:log4j"
 
 `,
-		Use:           "query SPDX_FILE \"query expression\" ",
+		Use:           "query SPDX_FILE|URL \"query expression\" ",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/spdx/package_test.go
+++ b/pkg/spdx/package_test.go
@@ -263,3 +263,23 @@ func TestComputeLicenseList(t *testing.T) {
 	require.NoError(t, p.ComputeLicenseList())
 	require.Equal(t, noLicenses, p.LicenseInfoFromFiles)
 }
+
+func TestIsURL(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		given string
+		isURL bool
+	}{
+		{"", false},
+		{"/", false},
+		{"/foo/bar", false},
+		{"http://", false},
+		{"http//foo.bar/baz", false},
+		{"https://foo.bar", true},
+		{"https://foo.bar/baz", true},
+	} {
+		res := isURL(tc.given)
+		require.Equal(t, tc.isURL, res)
+	}
+}


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows the automatic retrieval of uRL content, for example via:

```
bom document outline https://storage.googleapis.com/kubernetes-release-gcb/release/v1.26.0-alpha.1/kubernetes-release.spdx
```
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
cc @kubernetes-sigs/release-engineering 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow specifying URLs in `bom document query/outline`.
```
