### PR TITLE
Upgrade go1.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,21 @@
 version: 2
+
 updates:
+
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
+    interval: "daily"
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+  open-pull-requests-limit: 10
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
   labels:
     - "area/dependency"
     - "release-note-none"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
@@ -27,6 +27,6 @@ jobs:
         run: cd docs && npm install && hugo --minify
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@e6d003d0839927f5a4b998bfd92ed8e448fde37a # v4.3.4
+        uses: JamesIves/github-pages-deploy-action@13046b614c663b56cba4dda3f30b9736a748b80d # v4.4.0
         with:
           folder: ./docs/public # The folder the action should deploy.

--- a/.github/workflows/verify-spdx.yaml
+++ b/.github/workflows/verify-spdx.yaml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
         with:
-          go-version: 1.18
+          go-version: 1.19
           check-latest: true
 
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - run: |
           go run ./cmd/bom/main.go generate -i registry.k8s.io/pause > example-image-pause.spdx
           go run ./cmd/bom/main.go generate --format=json -i registry.k8s.io/pause > example-image-pause.spdx.json

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -51,16 +50,14 @@ linters:
     - predeclared
     - promlinter
     - revive
-    - rowserrcheck
-    - sqlclosecheck
+    #  - rowserrcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649
+    # - sqlclosecheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
     # - cyclop
     # - errorlint

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: ghcr.io/distroless/go:latest
+defaultBaseImage: ghcr.io/chainguard-images/go:latest
 
 builds:
 - id: bom

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -19,7 +19,7 @@ steps:
       echo "Checking out ${_PULL_BASE_REF}"
       git checkout ${_PULL_BASE_REF}
 
-  - name: 'gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye'
+  - name: 'gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye'
     dir: "go/src/sigs.k8s.io/bom"
     entrypoint: go
     env:

--- a/cmd/bom/cmd/document.go
+++ b/cmd/bom/cmd/document.go
@@ -40,54 +40,54 @@ func AddDocument(parent *cobra.Command) {
 }
 
 /*
-func AddQuery(parent *cobra.Command) {
-	queryCmd := &cobra.Command{
-		Short:             "bom document query → Query for data in an SPDX document",
-		Use:               "query SPDX_FILE",
-		SilenceUsage:      false,
-		SilenceErrors:     false,
-		PersistentPreRunE: initLogging,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) < 2 {
-				cmd.Help()
+	func AddQuery(parent *cobra.Command) {
+		queryCmd := &cobra.Command{
+			Short:             "bom document query → Query for data in an SPDX document",
+			Use:               "query SPDX_FILE",
+			SilenceUsage:      false,
+			SilenceErrors:     false,
+			PersistentPreRunE: initLogging,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				if len(args) < 2 {
+					cmd.Help()
+					return nil
+				}
+				doc, err := spdx.OpenDoc(args[0])
+				if err != nil {
+					return fmt.Errorf("opening document: %w", err)
+				}
+
+				// Parse the purl
+				pquery, err := purl.FromString(args[1])
+				if err != nil {
+					return fmt.Errorf(err, "parsing purl")
+				}
+
+				// Create the purl we will use to query
+				var purlType, purlNamespace, purlName, purlVersion string
+				if pquery.Type != "*" {
+					purlType = pquery.Type
+				}
+				if pquery.Name != "*" {
+					purlName = pquery.Name
+				}
+				if pquery.Version != "*" {
+					purlVersion = pquery.Version
+				}
+				if pquery.Namespace != "*" {
+					purlNamespace = pquery.Namespace
+				}
+				pSpec := purl.NewPackageURL(purlType, purlNamespace, purlName, purlVersion, purl.Qualifiers{}, "")
+
+				pkgs := doc.GetPackagesByPurl(pSpec)
+				for _, pk := range pkgs {
+					fmt.Printf("%s (%s)\n", pk.Name, pk.Purl())
+				}
 				return nil
-			}
-			doc, err := spdx.OpenDoc(args[0])
-			if err != nil {
-				return fmt.Errorf("opening document: %w", err)
-			}
-
-			// Parse the purl
-			pquery, err := purl.FromString(args[1])
-			if err != nil {
-				return fmt.Errorf(err, "parsing purl")
-			}
-
-			// Create the purl we will use to query
-			var purlType, purlNamespace, purlName, purlVersion string
-			if pquery.Type != "*" {
-				purlType = pquery.Type
-			}
-			if pquery.Name != "*" {
-				purlName = pquery.Name
-			}
-			if pquery.Version != "*" {
-				purlVersion = pquery.Version
-			}
-			if pquery.Namespace != "*" {
-				purlNamespace = pquery.Namespace
-			}
-			pSpec := purl.NewPackageURL(purlType, purlNamespace, purlName, purlVersion, purl.Qualifiers{}, "")
-
-			pkgs := doc.GetPackagesByPurl(pSpec)
-			for _, pk := range pkgs {
-				fmt.Printf("%s (%s)\n", pk.Name, pk.Purl())
-			}
-			return nil
-		},
+			},
+		}
+		parent.AddCommand(queryCmd)
 	}
-	parent.AddCommand(queryCmd)
-}
 */
 func AddOutline(parent *cobra.Command) {
 	outlineOpts := &spdx.DrawingOptions{}
@@ -113,7 +113,7 @@ set the --spdx-ids to only output the IDs of the entities.
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				cmd.Help() // nolint:errcheck
+				cmd.Help() //nolint:errcheck
 				return errors.New("you should only specify one file")
 			}
 			doc, err := spdx.OpenDoc(args[0])

--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -139,7 +139,7 @@ completed by a later stage in your CI/CD pipeline. See the
 			}
 
 			if err := genOpts.Validate(); err != nil {
-				cmd.Help() // nolint:errcheck // We already errored
+				cmd.Help() //nolint:errcheck // We already errored
 				return fmt.Errorf("validating command line options: %w", err)
 			}
 

--- a/cmd/bom/cmd/query.go
+++ b/cmd/bom/cmd/query.go
@@ -57,7 +57,7 @@ Example:
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
-				cmd.Help() // nolint:errcheck
+				cmd.Help() //nolint:errcheck
 				return errors.New("you should only specify one file")
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/bom
 
-go 1.18
+go 1.19
 
 require (
 	github.com/carolynvs/magex v0.9.0

--- a/magefile.go
+++ b/magefile.go
@@ -90,7 +90,7 @@ func Verify() error {
 	}
 
 	fmt.Println("Running golangci-lint...")
-	if err := mage.RunGolangCILint("v1.46.2", false); err != nil {
+	if err := mage.RunGolangCILint("v1.50.0", false); err != nil {
 		return err
 	}
 
@@ -248,7 +248,7 @@ func getBuildDateTime() string {
 func EnsureKO(version string) error {
 	versionToInstall := version
 	if versionToInstall == "" {
-		versionToInstall = "0.11.2"
+		versionToInstall = "0.12.0"
 	}
 
 	fmt.Printf("Checking if `ko` version %s is installed\n", versionToInstall)

--- a/pkg/osinfo/layer_scanner.go
+++ b/pkg/osinfo/layer_scanner.go
@@ -178,7 +178,7 @@ func (loss *LayerScanner) extractFileFromTar(tarPath, filePath, destPath string)
 				if !strings.HasPrefix(target, string(filepath.Separator)) {
 					newTarget := filepath.Dir(filePath)
 
-					// nolint:gosec // This is not zipslip, path it not used for writing just
+					//nolint:gosec // This is not zipslip, path it not used for writing just
 					// to search a file in the tarfile, the extract path is fexed.
 					newTarget = filepath.Join(newTarget, hdr.Linkname)
 					target = filepath.Clean(newTarget)

--- a/pkg/query/filter.go
+++ b/pkg/query/filter.go
@@ -162,7 +162,7 @@ func (cycler *ObjectCycler) CycleFull(objects map[string]spdx.Object, fn Matcher
 // Recursion will traverse the SBOM graph and return the element that
 // matches the query without continuing down its relationships
 func doRecursion(
-	// nolint:gocritic // seen is passed recursively
+	//nolint:gocritic // seen is passed recursively
 	objects map[string]spdx.Object, fn MatcherFunction, seen *map[string]struct{},
 ) map[string]spdx.Object {
 	newSet := map[string]spdx.Object{}
@@ -202,7 +202,7 @@ func doRecursion(
 // object, it will continue traversing its relationships returning all
 // matching objects in a flat array
 func doFullRecursion(
-	// nolint:gocritic // seen is passed recursively
+	//nolint:gocritic // seen is passed recursively
 	objects map[string]spdx.Object, fn MatcherFunction, seen *map[string]struct{},
 ) map[string]spdx.Object {
 	newSet := map[string]spdx.Object{}

--- a/pkg/spdx/file.go
+++ b/pkg/spdx/file.go
@@ -112,7 +112,8 @@ func (f *File) SetEntity(e *Entity) {
 }
 
 // Draw renders the file data as a tree-like structure
-// nolint:gocritic
+//
+//nolint:gocritic
 func (f *File) Draw(builder *strings.Builder, o *DrawingOptions, depth int, seen *map[string]struct{}) {
 	connector := connectorT
 	if o.LastItem {

--- a/pkg/spdx/file_test.go
+++ b/pkg/spdx/file_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package spdx
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,11 +24,11 @@ import (
 )
 
 func createTempFile(name string) (*os.File, string, error) {
-	dir, err := ioutil.TempDir("", "tests")
+	dir, err := os.MkdirTemp("", "tests")
 	if err != nil {
 		return nil, "", err
 	}
-	file, err := ioutil.TempFile(dir, name)
+	file, err := os.CreateTemp(dir, name)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/spdx/imageanalyzer.go
+++ b/pkg/spdx/imageanalyzer.go
@@ -26,9 +26,9 @@ import (
 )
 
 // ImageAnalyzer is an object that checks images to see if we can add more
-//  information to a spdx package based on its content. Each analyzer is
-//  written specifically for a layer type. The idea is to be able to enrich
-//  common base images with more data to have the most common images covered.
+// information to a spdx package based on its content. Each analyzer is
+// written specifically for a layer type. The idea is to be able to enrich
+// common base images with more data to have the most common images covered.
 type ImageAnalyzer struct {
 	Analyzers map[string]ContainerLayerAnalyzer
 }
@@ -53,9 +53,10 @@ func NewImageAnalyzer() *ImageAnalyzer {
 }
 
 // AnalyzeLayer is the main method of the analyzer
-//  it will query each of the analyzers to see if we can
-//  extract more image from the layer and enrich the
-//  spdx package referenced by pkg
+//
+//	it will query each of the analyzers to see if we can
+//	extract more image from the layer and enrich the
+//	spdx package referenced by pkg
 func (ia *ImageAnalyzer) AnalyzeLayer(layerPath string, pkg *Package) error {
 	if pkg == nil {
 		return errors.New("unable to analyze layer, package is null")

--- a/pkg/spdx/imageanalyzer_distroless.go
+++ b/pkg/spdx/imageanalyzer_distroless.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -143,7 +142,7 @@ func (h *distrolessHandler) ReadPackageData(layerPath string, pkg *Package) erro
 			// devian copyright files. We have to read the files so...
 			if spdxlicense == nil {
 				// ...open the file
-				fileData, err := ioutil.ReadFile(filepath.Join(dir, packageName+".license"))
+				fileData, err := os.ReadFile(filepath.Join(dir, packageName+".license"))
 				if err != nil {
 					return fmt.Errorf("reading license file: %w", err)
 				}
@@ -185,7 +184,8 @@ func (h *distrolessHandler) ReadPackageData(layerPath string, pkg *Package) erro
 }
 
 // fetchDistrolessPackages retrieves the package list published at the
-//  distroless repository keyed by package name and version
+//
+//	distroless repository keyed by package name and version
 func (h *distrolessHandler) fetchDistrolessPackages() (pkgInfo map[string]string, err error) {
 	logrus.Info("Fetching distroless image package list")
 	body, err := http.NewAgent().Get(distrolessBundleURL + distrolessBundle)

--- a/pkg/spdx/imageanalyzer_gorunner.go
+++ b/pkg/spdx/imageanalyzer_gorunner.go
@@ -21,7 +21,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -61,14 +60,14 @@ func (h *goRunnerHandler) ReadPackageData(layerPath string, pkg *Package) error 
 		return fmt.Errorf("fetching go-runner VERSION file: %w", err)
 	}
 
-	df, err := ioutil.TempFile(os.TempDir(), "gorunner-dockerfile-")
+	df, err := os.CreateTemp(os.TempDir(), "gorunner-dockerfile-")
 	if err != nil {
 		return fmt.Errorf("creating temporary file to read go-runner license: %w", err)
 	}
 	defer df.Close()
 	defer os.Remove(df.Name())
 
-	if err := ioutil.WriteFile(df.Name(), lic, os.FileMode(0o644)); err != nil {
+	if err := os.WriteFile(df.Name(), lic, os.FileMode(0o644)); err != nil {
 		return fmt.Errorf("writing go-runner license to temp file: %w", err)
 	}
 

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -171,7 +171,7 @@ func sanitizeExtractPath(tmpDir, filePath string) (string, error) {
 }
 
 // readArchiveManifest extracts the manifest json from an image tar
-//    archive and returns the data as a struct
+// archive and returns the data as a struct
 func (di *spdxDefaultImplementation) ReadArchiveManifest(manifestPath string) (manifest *ArchiveManifest, err error) {
 	// Check that we have the archive manifest.json file
 	if !util.Exists(manifestPath) {

--- a/pkg/spdx/object.go
+++ b/pkg/spdx/object.go
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:gosec
 // SHA1 is the currently accepted hash algorithm for SPDX documents, used for
 // file integrity checks, NOT security.
 // Instances of G401 and G505 can be safely ignored in this file.
 //
 // ref: https://github.com/spdx/spdx-spec/issues/11
+//
+//nolint:gosec
 package spdx
 
 import (
@@ -136,7 +137,8 @@ func (e *Entity) ReadChecksums(filePath string) error {
 }
 
 // ReadSourceFile reads the source file for the package and populates
-//  the fields derived from it (Checksums and FileName)
+//
+//	the fields derived from it (Checksums and FileName)
 func (e *Entity) ReadSourceFile(path string) error {
 	if !util.Exists(path) {
 		return errors.New("unable to find package source file")
@@ -208,7 +210,8 @@ func (e *Entity) ToProvenanceSubject() *intoto.Subject {
 
 // getProvenanceSubjects regturns all provenance subjects found in this
 // entity by scanning all relationships recursively
-// nolint:gocritic // seen needs to be a pointer as it is used recursively
+//
+//nolint:gocritic // seen needs to be a pointer as it is used recursively
 func (e *Entity) getProvenanceSubjects(opts *ProvenanceOptions, seen *map[string]struct{}) []intoto.Subject {
 	ret := []intoto.Subject{}
 

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -358,7 +358,8 @@ func (p *Package) SetEntity(e *Entity) {
 }
 
 // Draw renders the package data as a tree-like structure
-// nolint:gocritic
+//
+//nolint:gocritic
 func (p *Package) Draw(builder *strings.Builder, o *DrawingOptions, depth int, seen *map[string]struct{}) {
 	title := p.SPDXID()
 	(*seen)[p.SPDXID()] = struct{}{}

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -225,8 +225,9 @@ func (spdx *SPDX) FileFromPath(filePath string) (*File, error) {
 }
 
 // AnalyzeLayer uses the collection of image analyzers to see if
-//  it matches a known image from which a spdx package can be
-//  enriched with more information
+//
+//	it matches a known image from which a spdx package can be
+//	enriched with more information
 func (spdx *SPDX) AnalyzeImageLayer(layerPath string, pkg *Package) error {
 	return spdx.impl.AnalyzeImageLayer(layerPath, pkg)
 }
@@ -243,11 +244,11 @@ func (spdx *SPDX) PullImagesToArchive(reference, path string) (*ImageReferenceIn
 
 // ImageRefToPackage gets an image reference (tag or digest) and returns
 // a spdx package describing it. It can take two forms:
-//  - When the reference is a digest (or single image), a single package
-//    describing the layers is returned
-//  - When the reference is an image index, the returned package is a
-//    package referencing each of the images, each in its own packages.
-//  All subpackages are returned with a relationship of VARIANT_OF
+//   - When the reference is a digest (or single image), a single package
+//     describing the layers is returned
+//   - When the reference is an image index, the returned package is a
+//     package referencing each of the images, each in its own packages.
+//     All subpackages are returned with a relationship of VARIANT_OF
 func (spdx *SPDX) ImageRefToPackage(reference string) (pkg *Package, err error) {
 	return spdx.impl.ImageRefToPackage(reference, spdx.Options())
 }
@@ -262,7 +263,8 @@ func Banner() string {
 
 // recursiveIDSearch is a function that recursively searches an object's peers
 // to find the specified SPDX ID. If found, returns a copy of the object.
-// nolint:gocritic // seen is a pointer recursively populated
+//
+//nolint:gocritic // seen is a pointer recursively populated
 func recursiveIDSearch(id string, o Object, seen *map[string]struct{}) Object {
 	if o.SPDXID() == id {
 		return o
@@ -290,7 +292,8 @@ func recursiveIDSearch(id string, o Object, seen *map[string]struct{}) Object {
 // recursivePurlSearch is a function that recursively searches an object's peers
 // to find those that match the purl parts defined. If found, returns a copy of
 // the object.
-// nolint:gocritic // seen is a pointer recursively populated
+//
+//nolint:gocritic // seen is a pointer recursively populated
 func recursivePurlSearch(purlSpec *purl.PackageURL, o Object, seen *map[string]struct{}, opts ...PurlSearchOption) []*Package {
 	foundPackages := []*Package{}
 	// Only packages can express purls

--- a/pkg/spdx/spdx_unit_test.go
+++ b/pkg/spdx/spdx_unit_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -184,7 +183,7 @@ func writeTestTarball(t *testing.T, zipped bool) *os.File {
 	zipreader, err := gzip.NewReader(reader)
 	require.Nil(t, err)
 
-	bindata, err := ioutil.ReadAll(zipreader)
+	bindata, err := io.ReadAll(zipreader)
 	require.Nil(t, err)
 
 	require.Nil(t, os.WriteFile(


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

- enable dependabot for github actions
- update actions
- bump go to 1.19


/assign @puerco @saschagrunert @Verolop @xmudrii 

need: https://github.com/kubernetes/test-infra/pull/27732

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
bump go to 1.19
```
