### PR TITLE
Make license package more resilient to unexpected output

### DIFF
--- a/pkg/license/implementation.go
+++ b/pkg/license/implementation.go
@@ -51,6 +51,13 @@ func (d *ReaderDefaultImpl) ClassifyFile(path string) (licenseTag string, moreTa
 	moreTags = []string{}
 	allTags := map[string]struct{}{}
 	for _, match := range res.Matches {
+		// As of v2.0.0, the license classifier returns "Copyright"
+		// as one of the license tags. If we let it go the license module
+		// will ignore it but it will write it to the debug output.
+		// So we simply skip it.
+		if match.Name == "Copyright" {
+			continue
+		}
 		if match.Confidence > highestConf {
 			highestConf = match.Confidence
 			licenseTag = match.Name
@@ -96,7 +103,7 @@ func (d *ReaderDefaultImpl) ClassifyLicenseFiles(paths []string) (
 		licenseList = append(licenseList, &ClassifyResult{f, string(licenseText), license})
 	}
 	if len(paths) != len(licenseList) {
-		logrus.Infof(
+		logrus.Debugf(
 			"License classifier recognized %d/%d (%d%%) of the license files",
 			len(licenseList), len(paths), (len(licenseList)/len(paths))*100,
 		)

--- a/pkg/license/implementation.go
+++ b/pkg/license/implementation.go
@@ -91,7 +91,7 @@ func (d *ReaderDefaultImpl) ClassifyLicenseFiles(paths []string) (
 		// Get the license corresponding to the ID label
 		license := d.catalog.GetLicense(label)
 		if license == nil {
-			logrus.Debug("got an unknown license label from classifier: %s", label)
+			logrus.Debugf("Got an unknown license label from classifier: %s", label)
 			unrecognizedPaths = append(unrecognizedPaths, f)
 			continue
 		}
@@ -141,7 +141,7 @@ func (d *ReaderDefaultImpl) LicenseFromFile(path string) (license *License, err 
 
 // FindLicenseFiles will scan a directory and return files that may be licenses
 func (d *ReaderDefaultImpl) FindLicenseFiles(path string) ([]string, error) {
-	logrus.Infof("Scanning %s for license files", path)
+	logrus.Debugf("Scanning %s for license files", path)
 	licenseList := []string{}
 	re := regexp.MustCompile(licenseFilanameRe)
 	if err := filepath.Walk(path,
@@ -167,7 +167,7 @@ func (d *ReaderDefaultImpl) FindLicenseFiles(path string) ([]string, error) {
 		}); err != nil {
 		return nil, fmt.Errorf("scanning the directory for license files: %w", err)
 	}
-	logrus.Infof("%d license files found in directory", len(licenseList))
+	logrus.Debugf("%d license files found in directory %s", len(licenseList), path)
 	return licenseList, nil
 }
 

--- a/pkg/license/implementation.go
+++ b/pkg/license/implementation.go
@@ -63,7 +63,6 @@ func (d *ReaderDefaultImpl) ClassifyFile(path string) (licenseTag string, moreTa
 			moreTags = append(moreTags, t)
 		}
 	}
-	logrus.Infof("File %s classified as license %s plus %+v", path, licenseTag, moreTags)
 	return licenseTag, moreTags, nil
 }
 
@@ -85,8 +84,9 @@ func (d *ReaderDefaultImpl) ClassifyLicenseFiles(paths []string) (
 		// Get the license corresponding to the ID label
 		license := d.catalog.GetLicense(label)
 		if license == nil {
-			return nil, unrecognizedPaths,
-				fmt.Errorf("ID does not correspond to a valid license: '%s'", label)
+			logrus.Debug("got an unknown license label from classifier: %s", label)
+			unrecognizedPaths = append(unrecognizedPaths, f)
+			continue
 		}
 		licenseText, err := os.ReadFile(f)
 		if err != nil {
@@ -125,7 +125,8 @@ func (d *ReaderDefaultImpl) LicenseFromFile(path string) (license *License, err 
 	// Get the license corresponding to the ID label
 	license = d.catalog.GetLicense(label)
 	if license == nil {
-		return nil, fmt.Errorf("ID does not correspond to a valid license: %s", label)
+		logrus.Debugf("ID returned by classifier does not correspond to a valid license tag: %s", label)
+		return nil, nil
 	}
 
 	return license, nil

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -180,7 +180,7 @@ func (r *Reader) ReadTopLicense(path string) (*ClassifyResult, error) {
 			return nil, fmt.Errorf("scanning topmost license file: %w", err)
 		}
 		if len(result) != 0 {
-			logrus.Infof("Concluded license %s from %s", result[0].License.LicenseID, licenseFilePath)
+			logrus.Debugf("Concluded license %s from %s", result[0].License.LicenseID, licenseFilePath)
 			return result[0], nil
 		}
 	}
@@ -224,9 +224,9 @@ func (r *Reader) ReadTopLicense(path string) (*ClassifyResult, error) {
 		}
 	}
 	if res == nil {
-		logrus.Warnf("Could not find any licensing information in %s", path)
+		logrus.Debugf("Could not find any licensing information in %s", path)
 	} else {
-		logrus.Infof("Concluded license %s from %s", res.License.LicenseID, licenseFilePath)
+		logrus.Debugf("Concluded license %s from %s", res.License.LicenseID, licenseFilePath)
 	}
 	return res, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

This PR improves the licensing code to be more resilient when encountering unexpected license tags in the
classifier output. Since v2.0.0, [the classifier will now return a pseudo license tag when finding copyright information] in files. This caused our libraries to return an error when scanning files.

It also fixes another bug where the secondary license list was lost after scanning and classifying a file. 

The verbosity of the licensing code has now been reduced to make it more understandable.

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2729

#### Special notes for your reviewer:

/assign @jeremyrickard @xmudrii @cpanato 

#### Does this PR introduce a user-facing change?


```release-note
- Fixed a bug where the secondary license list returned by the classifier was not being returned
- Improved the licensing code to be more resilient to unexpected output from the classifier
- Licensing output is now less verbose. Use `--log-level=debug` to see all messages
```
