### PR TITLE
Fix panic in outliner

### DIFF
--- a/pkg/spdx/parser.go
+++ b/pkg/spdx/parser.go
@@ -371,7 +371,7 @@ func parseJSON(file *os.File) (doc *Document, err error) {
 		}
 
 		if f, ok = allFiles[el]; ok {
-			doc.Files[p.SPDXID()] = f
+			doc.Files[f.SPDXID()] = f
 			seenObjects[el] = el
 			continue
 		}


### PR DESCRIPTION

#### What type of PR is this?
:
/kind bug

#### What this PR does / why we need it:

This commit fixes a panic in the document outliner where bom would crash when the sbom contains files at the top level of the sbom:

```
om document outline example11/spdx/sbom.spdx.json 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x85b8be]

goroutine 1 [running]:
sigs.k8s.io/bom/pkg/spdx.parseJSON(0x7ffc5908f0e5?)
	sigs.k8s.io/bom/pkg/spdx/parser.go:374 +0x111e
sigs.k8s.io/bom/pkg/spdx.OpenDoc({0x7ffc5908f0e5?, 0x1d?})
	sigs.k8s.io/bom/pkg/spdx/parser.go:86 +0x346
sigs.k8s.io/bom/cmd/bom/cmd.AddOutline.func1(0xc000248600?, {0xc0001efa70?, 0x1?, 0x1?})
	sigs.k8s.io/bom/cmd/bom/cmd/document.go:119 +0x3f
github.com/spf13/cobra.(*Command).execute(0xc000248600, {0xc0001efa30, 0x1, 0x1})
	github.com/spf13/cobra@v1.6.0/command.go:916 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xd793e0)
	github.com/spf13/cobra@v1.6.0/command.go:1040 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.6.0/command.go:968
sigs.k8s.io/bom/cmd/bom/cmd.Execute()
	sigs.k8s.io/bom/cmd/bom/cmd/root.go:71 +0x25
main.main()
	./main.go:24 +0x17

```

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

/assign @saschagrunert @cpanato @xmudrii 

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where bom would crash when outlining an SBOM containing files at the top level of the document..
```
