### PR TITLE
Fix b0rk when supplier is NOASSERTION

### DIFF
--- a/pkg/spdx/parser.go
+++ b/pkg/spdx/parser.go
@@ -559,10 +559,13 @@ func parseTagValue(file *os.File) (doc *Document, err error) {
 				currentObject.(*Package).LicenseInfoFromFiles = append(currentObject.(*Package).LicenseInfoFromFiles, value)
 			}
 		case "PackageSupplier":
+			if value == NOASSERTION {
+				continue
+			}
 			// Supplier has a tag/value format inside
 			match := tagRegExp.FindStringSubmatch(value)
 			if len(match) != 3 {
-				return nil, fmt.Errorf("invalid creator tag syntax at line %d", i)
+				return nil, fmt.Errorf("invalid supplier tag syntax at line %d: %s", i, value)
 			}
 			switch match[1] {
 			case entPerson:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes a bug where SBOMs could not be ingested when the supplier of a package was set to `NOASSERTION`.

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>

#### Which issue(s) this PR fixes:

/cc @jeremyrickard @xmudrii 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug where SBOMs were not ingested when the supplier of a package was `NOASSERTION`.
```
