### PR TITLE
Versions and purls in document outliner

### DIFF
--- a/cmd/bom/cmd/document.go
+++ b/cmd/bom/cmd/document.go
@@ -143,6 +143,18 @@ set the --spdx-ids to only output the IDs of the entities.
 		false,
 		"use SPDX identifiers in tree nodes instead of names",
 	)
+	outlineCmd.PersistentFlags().BoolVar(
+		&outlineOpts.Version,
+		"version",
+		true,
+		"show versions along with package names",
+	)
+	outlineCmd.PersistentFlags().BoolVar(
+		&outlineOpts.Purls,
+		"purl",
+		false,
+		"show package urls instead of name@version",
+	)
 
 	parent.AddCommand(outlineCmd)
 }

--- a/pkg/spdx/document.go
+++ b/pkg/spdx/document.go
@@ -124,6 +124,8 @@ type DrawingOptions struct {
 	SkipName    bool
 	OnlyIDs     bool
 	ASCIIOnly   bool
+	Purls       bool
+	Version     bool
 }
 
 // String returns the SPDX string of the external document ref

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -370,6 +370,20 @@ func (p *Package) drawTitle(o *DrawingOptions) string {
 	return title
 }
 
+// drawName returns the name string to be used in the outline
+func (p *Package) drawName(o *DrawingOptions) string {
+	name := p.SPDXID()
+	if o.Purls && p.Purl() != nil && p.Purl().Name != "" {
+		name = p.Purl().String()
+	} else if p.Name != "" {
+		name = p.Name
+		if o.Version && p.Version != "" {
+			name = name + "@" + p.Version
+		}
+	}
+	return name
+}
+
 // Draw renders the package data as a tree-like structure
 //
 //nolint:gocritic
@@ -411,14 +425,7 @@ func (p *Package) Draw(builder *strings.Builder, o *DrawingOptions, depth int, s
 
 			if !o.OnlyIDs {
 				if _, ok := rel.Peer.(*Package); ok {
-					if o.Purls && rel.Peer.(*Package).Purl() != nil && rel.Peer.(*Package).Purl().Name != "" {
-						name = rel.Peer.(*Package).Purl().String()
-					} else {
-						name = rel.Peer.(*Package).Name
-						if o.Version && rel.Peer.(*Package).Version != "" {
-							name = name + "@" + rel.Peer.(*Package).Version
-						}
-					}
+					name = rel.Peer.(*Package).drawName(o)
 					etype = "PACKAGE"
 				}
 

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -357,13 +357,8 @@ func (p *Package) SetEntity(e *Entity) {
 	p.Entity = *e
 }
 
-// Draw renders the package data as a tree-like structure
-//
-//nolint:gocritic
-func (p *Package) Draw(builder *strings.Builder, o *DrawingOptions, depth int, seen *map[string]struct{}) {
+func (p *Package) drawTitle(o *DrawingOptions) string {
 	title := p.SPDXID()
-	(*seen)[p.SPDXID()] = struct{}{}
-
 	if o.Purls && p.Purl() != nil && p.Purl().Name != "" {
 		title = p.Purl().String()
 	} else if p.Name != "" {
@@ -372,7 +367,16 @@ func (p *Package) Draw(builder *strings.Builder, o *DrawingOptions, depth int, s
 			title += "@" + p.Version
 		}
 	}
+	return title
+}
 
+// Draw renders the package data as a tree-like structure
+//
+//nolint:gocritic
+func (p *Package) Draw(builder *strings.Builder, o *DrawingOptions, depth int, seen *map[string]struct{}) {
+	(*seen)[p.SPDXID()] = struct{}{}
+
+	title := p.drawTitle(o)
 	if !o.SkipName {
 		fmt.Fprintln(builder, treeLines(o, depth-1, connectorT)+title)
 	}

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -433,15 +433,6 @@ func (p *Package) Draw(builder *strings.Builder, o *DrawingOptions, depth int, s
 			line += " (external)"
 		}
 
-		// Version is useful for dependencies, so add it:
-		if rel.Type == DEPENDS_ON {
-			if _, ok := rel.Peer.(*Package); ok {
-				if rel.Peer.(*Package).Version != "" {
-					line += fmt.Sprintf(" (version %s)", rel.Peer.(*Package).Version)
-				}
-			}
-		}
-
 		// If it is a file, print the name
 		if _, ok := rel.Peer.(*File); ok {
 			if rel.Peer.(*File).Name != "" {

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -363,9 +363,16 @@ func (p *Package) SetEntity(e *Entity) {
 func (p *Package) Draw(builder *strings.Builder, o *DrawingOptions, depth int, seen *map[string]struct{}) {
 	title := p.SPDXID()
 	(*seen)[p.SPDXID()] = struct{}{}
-	if p.Name != "" {
+
+	if o.Purls && p.Purl() != nil && p.Purl().Name != "" {
+		title = p.Purl().String()
+	} else if p.Name != "" {
 		title = p.Name
+		if o.Version && p.Version != "" {
+			title += "@" + p.Version
+		}
 	}
+
 	if !o.SkipName {
 		fmt.Fprintln(builder, treeLines(o, depth-1, connectorT)+title)
 	}
@@ -400,7 +407,14 @@ func (p *Package) Draw(builder *strings.Builder, o *DrawingOptions, depth int, s
 
 			if !o.OnlyIDs {
 				if _, ok := rel.Peer.(*Package); ok {
-					name = rel.Peer.(*Package).Name
+					if o.Purls && rel.Peer.(*Package).Purl() != nil && rel.Peer.(*Package).Purl().Name != "" {
+						name = rel.Peer.(*Package).Purl().String()
+					} else {
+						name = rel.Peer.(*Package).Name
+						if o.Version && rel.Peer.(*Package).Version != "" {
+							name = name + "@" + rel.Peer.(*Package).Version
+						}
+					}
 					etype = "PACKAGE"
 				}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR improves the document outliner by introducing two small features:

1 . The outliner will now print versions by default along with the package names (decided from [this very scientific Twitter poll](https://twitter.com/puerco/status/1598484226902560776)). This can be turned off by specifying `--version=false`

![image](https://user-images.githubusercontent.com/3935899/207764256-2c03c346-67ef-4314-b00d-e44106154914.png)

2 .  A new `--purl` flag will display purls instead of names for each node in the SBOM graph (when available):

![image](https://user-images.githubusercontent.com/3935899/207764442-ed90b994-9ba2-42e4-8fd1-9ea768691d08.png)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?


```release-note
- `bom document outline` now displays version numbers along package names by default. This can be turned off with `--version=false`
- The `oultine` subcommand has a new `---purl` flag which will display purls instead of package names when outlining an SBOM
```
