### PR TITLE
Purl(): Support both PACKAGE-MANAGER and PACKAGE-MANAGER

### DIFF
--- a/pkg/query/filter_test.go
+++ b/pkg/query/filter_test.go
@@ -38,7 +38,7 @@ func testPackages() map[string]*spdx.Package {
 		}
 		p.ExternalRefs = []spdx.ExternalRef{
 			{
-				Category: "PACKAGE-MANAGER",
+				Category: spdx.CatPackageManager,
 				Type:     "purl",
 				Locator: fmt.Sprintf(
 					"pkg:oci/%s@%s?repository_url=%s&tag=nginx", s, dg, repo,

--- a/pkg/spdx/gomod.go
+++ b/pkg/spdx/gomod.go
@@ -114,7 +114,7 @@ func (pkg *GoPackage) ToSPDXPackage() (*Package, error) {
 	spdxPackage.CopyrightText = pkg.CopyrightText
 	if packageurl := pkg.PackageURL(); packageurl != "" {
 		spdxPackage.ExternalRefs = append(spdxPackage.ExternalRefs, ExternalRef{
-			Category: "PACKAGE-MANAGER",
+			Category: CatPackageManager,
 			Type:     "purl",
 			Locator:  packageurl,
 		})

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -762,7 +762,7 @@ func (di *spdxDefaultImplementation) ImageRefToPackage(ref string, opts *Options
 	packageurl := di.purlFromImage(references)
 	if packageurl != "" {
 		pkg.ExternalRefs = append(pkg.ExternalRefs, ExternalRef{
-			Category: "PACKAGE-MANAGER",
+			Category: CatPackageManager,
 			Type:     "purl",
 			Locator:  packageurl,
 		})
@@ -789,7 +789,7 @@ func (di *spdxDefaultImplementation) referenceInfoToPackage(opts *Options, img *
 	packageurl := di.purlFromImage(img)
 	if packageurl != "" {
 		subpkg.ExternalRefs = append(subpkg.ExternalRefs, ExternalRef{
-			Category: "PACKAGE-MANAGER",
+			Category: CatPackageManager,
 			Type:     "purl",
 			Locator:  packageurl,
 		})
@@ -917,7 +917,7 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 				}
 				if (*osPackageData)[i].PackageURL() != "" {
 					ospk.ExternalRefs = append(ospk.ExternalRefs, ExternalRef{
-						Category: "PACKAGE-MANAGER",
+						Category: CatPackageManager,
 						Type:     "purl",
 						Locator:  (*osPackageData)[i].PackageURL(),
 					})

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -122,8 +122,10 @@ var PackagePurposes = []string{
 
 var ExternalRefCategories = map[string][]string{
 	"SECURITY":        {"cpe22Type", "cpe23Type", "advisory", "fix", "url", "swid"},
+	"PACKAGE_MANAGER": {"maven-central", "npm", "nuget", "bower", "purl"},
 	"PACKAGE-MANAGER": {"maven-central", "npm", "nuget", "bower", "purl"},
 	"PERSISTENT-ID":   {"swh", "gitoid"},
+	"PERSISTENT_ID":   {"swh", "gitoid"},
 	"OTHER":           {},
 }
 
@@ -503,14 +505,14 @@ func (p *Package) GetElementByID(id string) Object {
 }
 
 // Purl searches the external refs in the package and returns
-// a pursed purl if it finds a purl PACKAGE-MANAGER
+// a parsed purl if it finds a purl PACKAGE_MANAGER extref:
 func (p *Package) Purl() *purl.PackageURL {
 	if p.ExternalRefs == nil {
 		return nil
 	}
 	purlString := ""
 	for _, er := range p.ExternalRefs {
-		if er.Category == "PACKAGE-MANAGER" && er.Type == "purl" {
+		if (er.Category == "PACKAGE-MANAGER" || er.Category == "PACKAGE_MANAGER") && er.Type == "purl" {
 			purlString = er.Locator
 		}
 	}
@@ -520,7 +522,7 @@ func (p *Package) Purl() *purl.PackageURL {
 	// Parse the purl
 	purlObject, err := purl.FromString(purlString)
 	if err != nil {
-		logrus.Warnf("Invalid Purl in package %s: %s", p.SPDXID(), purlString)
+		logrus.Warnf("Invalid purl in package %s: %s", p.SPDXID(), purlString)
 		return nil
 	}
 	return &purlObject

--- a/pkg/spdx/package_test.go
+++ b/pkg/spdx/package_test.go
@@ -27,6 +27,15 @@ import (
 func TestPurl(t *testing.T) {
 	pkg := NewPackage()
 	pkg.ExternalRefs = []ExternalRef{{
+		Category: CatPackageManager,
+		Type:     "purl",
+		Locator:  "pkg:deb/debian/libtiff5@4.2.0-1?arch=amd64",
+	}}
+
+	require.NotNil(t, pkg.Purl())
+
+	// We need support both hyphens in PACKAGE[-_]MANAGER:
+	pkg.ExternalRefs = []ExternalRef{{
 		Category: "PACKAGE-MANAGER",
 		Type:     "purl",
 		Locator:  "pkg:deb/debian/libtiff5@4.2.0-1?arch=amd64",
@@ -36,7 +45,7 @@ func TestPurl(t *testing.T) {
 
 	// Invalid
 	pkg.ExternalRefs = []ExternalRef{{
-		Category: "PACKAGE-MANAGER",
+		Category: CatPackageManager,
 		Type:     "purl",
 		Locator:  "pkg: lsa slkdj l lkjlsl kjsl l sl kjs",
 	}}
@@ -45,7 +54,7 @@ func TestPurl(t *testing.T) {
 
 	// Validate the purl fields
 	pkg.ExternalRefs = []ExternalRef{{
-		Category: "PACKAGE-MANAGER",
+		Category: CatPackageManager,
 		Type:     "purl",
 		Locator:  "pkg:deb/debian/libicu67@67.1-7?arch=s390x",
 	}}
@@ -131,7 +140,7 @@ func TestPurlMatches(t *testing.T) {
 	} {
 		sut := NewPackage()
 		sut.ExternalRefs = append(sut.ExternalRefs, ExternalRef{
-			Category: "PACKAGE-MANAGER",
+			Category: CatPackageManager,
 			Type:     "purl",
 			Locator:  tc.purl,
 		})

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -48,6 +48,8 @@ const (
 	entTool         = "Tool"
 	entOrganization = "Organization"
 
+	CatPackageManager = "PACKAGE-MANAGER"
+
 	termBanner = `ICAgICAgICAgICAgICAgXyAgICAgIAogX19fIF8gX18gICBfX3wgfF8gIF9fCi8gX198ICdfIFwg
 LyBfYCBcIFwvIC8KXF9fIFwgfF8pIHwgKF98IHw+ICA8IAp8X19fLyAuX18vIFxfXyxfL18vXF9c
 CiAgICB8X3wgICAgICAgICAgICAgICAK`


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This PR modifies `bom` to support the ingestion of external references with both `PACKAGE-MANAGER` and `PACKAGE-MANAGER` in the category field. In SPDX 2.3 it was changed and the agreement during the tech call was to support both cases. 

This change echoes the same [change already done in the SPDX java tools](https://github.com/spdx/tools-java/pull/76/files#diff-2d62de45a362cf43a5c97c9481212a3f8b485b8488aeea7415fb5b7b5dfc2d8cL325).

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
SBOM ingestion now supports external references with both `PACKAGE-MANAGER` and `PACKAGE-MANAGER` in the category field. Output is always SPDX 2.3 which calls for `PACKAGE-MANAGER` in the schema.
```
