### PR TITLE
Fix bug breaking license downloads

### DIFF
--- a/pkg/license/catalog.go
+++ b/pkg/license/catalog.go
@@ -91,7 +91,6 @@ func (catalog *Catalog) WriteLicensesAsText(targetDir string) error {
 	}
 
 	var wg errgroup.Group
-	var err error
 	for _, l := range catalog.List.Licenses {
 		l := l
 		wg.Go(func() error {
@@ -100,16 +99,12 @@ func (catalog *Catalog) WriteLicensesAsText(targetDir string) error {
 			}
 			licPath := filepath.Join(targetDir, "assets", l.LicenseID)
 			if !util.Exists(licPath) {
-				if err = os.MkdirAll(licPath, 0o755); err != nil {
-					err = fmt.Errorf("creating license directory: %w", err)
+				if err := os.MkdirAll(licPath, 0o755); err != nil {
+					return fmt.Errorf("creating license directory: %w", err)
 				}
 			}
-			if lerr := l.WriteText(filepath.Join(licPath, "license.txt")); err != nil {
-				if err == nil {
-					err = lerr
-				} else {
-					err = fmt.Errorf("%v: %w", lerr, err)
-				}
+			if err := l.WriteText(filepath.Join(licPath, "license.txt")); err != nil {
+				return fmt.Errorf("wriiting license text: %w", err)
 			}
 			return nil
 		})

--- a/pkg/license/download.go
+++ b/pkg/license/download.go
@@ -121,7 +121,7 @@ func (d *Downloader) GetLicenses() (*List, error) {
 	if tag == "" {
 		tag, err = d.impl.GetLatestTag()
 		if err != nil {
-			return nil, fmt.Errorf("getting latest license list tag")
+			return nil, fmt.Errorf("getting latest license list tag: %w", err)
 		}
 	}
 
@@ -169,15 +169,16 @@ func (ddi *DefaultDownloaderImpl) GetLatestTag() (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("getting latest version from cache: %w", err)
 		}
-		if err := ddi.cacheData(LatestReleaseURL, data); err != nil {
-			return "", fmt.Errorf("caching latest version: %w", err)
-		}
 	}
 
 	if data == nil {
 		data, err = http.NewAgent().Get(LatestReleaseURL)
 		if err != nil {
 			return "", err
+		}
+
+		if err := ddi.cacheData(LatestReleaseURL, data); err != nil {
+			return "", fmt.Errorf("caching latest version: %w", err)
 		}
 	}
 	type GHReleaseResp struct {
@@ -277,6 +278,7 @@ func (ddi *DefaultDownloaderImpl) cacheData(url string, data []byte) error {
 	if err = os.WriteFile(cacheFileName, data, os.FileMode(0o644)); err != nil {
 		return fmt.Errorf("writing cache file: %w", err)
 	}
+	logrus.Debugf("Cached %s to %s", url, cacheFileName)
 	return nil
 }
 

--- a/pkg/license/download.go
+++ b/pkg/license/download.go
@@ -14,19 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// SHA1 is the currently accepted hash algorithm for SPDX documents, used for
-// file integrity checks, NOT security.
-// Instances of G401 and G505 can be safely ignored in this file.
-//
-// ref: https://github.com/spdx/spdx-spec/issues/11
-//
-//nolint:gosec
 package license
 
 import (
 	"archive/zip"
 	"bytes"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -262,7 +255,7 @@ func (ddi *DefaultDownloaderImpl) GetLicenses(tag string) (licenses *List, err e
 // cacheFileName return the cache filename for an URL
 func (ddi *DefaultDownloaderImpl) cacheFileName(url string) string {
 	return filepath.Join(
-		ddi.Options.CacheDir, fmt.Sprintf("%x.json", sha1.Sum([]byte(url))),
+		ddi.Options.CacheDir, fmt.Sprintf("%x.json", sha256.New().Sum([]byte(url))),
 	)
 }
 

--- a/pkg/license/download.go
+++ b/pkg/license/download.go
@@ -294,7 +294,7 @@ func (ddi *DefaultDownloaderImpl) getCachedData(url string) ([]byte, error) {
 	}
 
 	if finfo.Size() == 0 {
-		logrus.Warn("Cached file is empty, removing")
+		logrus.Warnf("Cached file %s is empty, removing", cacheFileName)
 		return nil, fmt.Errorf("removing corrupt cached file: %w", os.Remove(cacheFileName))
 	}
 	cachedData, err := os.ReadFile(cacheFileName)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes a bug that broke the license downloader. The downloader cache was being 
called at the wrong place and always returned null data.

It also fixes an unreported bug where download errors were being handled wrong and changes the 
hashing algorithm for cache entries from sha1 to sha256.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:


The main bug fix is in e85ab924cb760d7308793e4df74e03e246b74826

/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where the license downloader was always returning nil data leading to licenses not being detected.
```
