### PR TITLE
Change tool string to include version

### DIFF
--- a/pkg/serialize/serialize.go
+++ b/pkg/serialize/serialize.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/bom/pkg/query"
 	"sigs.k8s.io/bom/pkg/spdx"
 	spdxJSON "sigs.k8s.io/bom/pkg/spdx/json/v2.3"
+	"sigs.k8s.io/release-utils/version"
 )
 
 type Serializer interface {
@@ -49,6 +50,7 @@ func (json *JSON) Serialize(doc *spdx.Document) (string, error) {
 	if _, err := doc.Render(); err != nil {
 		return "", fmt.Errorf("pre-rendering the document: %w", err)
 	}
+
 	jsonDoc := spdxJSON.Document{
 		ID:      doc.ID,
 		Name:    doc.Name,
@@ -56,7 +58,7 @@ func (json *JSON) Serialize(doc *spdx.Document) (string, error) {
 		CreationInfo: spdxJSON.CreationInfo{
 			Created: time.Now().UTC().Format("2006-01-02T15:04:05Z07:00"),
 			Creators: []string{
-				"Tool: sigs.k8s.io/bom/pkg/spdx",
+				fmt.Sprintf("Tool: %s-%s", "bom", version.GetVersionInfo().GitVersion),
 			},
 			LicenseListVersion: "",
 		},

--- a/pkg/spdx/document.go
+++ b/pkg/spdx/document.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/bom/pkg/provenance"
 	"sigs.k8s.io/release-utils/hash"
 	"sigs.k8s.io/release-utils/util"
+	"sigs.k8s.io/release-utils/version"
 )
 
 var docTemplate = `{{ if .Version }}SPDXVersion: {{.Version}}
@@ -171,7 +172,9 @@ func NewDocument() *Document {
 		}{
 			Person:       defaultDocumentAuthor,
 			Organization: "Kubernetes Release Engineering",
-			Tool:         []string{"sigs.k8s.io/bom/pkg/spdx"},
+			Tool: []string{
+				fmt.Sprintf("%s-%s", "bom", version.GetVersionInfo().GitVersion),
+			},
 		},
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

This commit changes the tool string to add the tool version in the document Creator version. It will now pick up the tag+commit version when building a non-tagged version or "devel" when running without tags.


#### Which issue(s) this PR fixes:

Fixes #235
\
#### Special notes for your reviewer:

/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?


```release-note
- Fixed a bug where the tool version was not getting included in the document creator info. The new Creator field has the app name, version tag and commit: ``bom-v0.4.1-102-g98baf66
```
