### PR TITLE
Improve handling of 2.3 optional fields

### DIFF
--- a/pkg/serialize/serialize.go
+++ b/pkg/serialize/serialize.go
@@ -127,7 +127,7 @@ func (json *JSON) Serialize(doc *spdx.Document) (string, error) {
 }
 
 // buildJSONPackage converts a SPDX package struct to a json package
-// TODO(pueco): Validate package information to make sure its a valid package
+// TODO(puerco): Validate package information to make sure its a valid package
 func (json *JSON) buildJSONPackage(p *spdx.Package) (jsonPackage spdxJSON.Package, err error) {
 	// Update the Verification code
 	if err := p.ComputeVerificationCode(); err != nil {
@@ -159,10 +159,14 @@ func (json *JSON) buildJSONPackage(p *spdx.Package) (jsonPackage spdxJSON.Packag
 		HasFiles:             []string{},
 		Checksums:            []spdxJSON.Checksum{},
 		ExternalRefs:         externalRefs,
-		VerificationCode: spdxJSON.PackageVerificationCode{
-			Value: p.VerificationCode,
-		},
 	}
+
+	if p.VerificationCode != "" {
+		jsonPackage.VerificationCode = &spdxJSON.PackageVerificationCode{
+			Value: p.VerificationCode,
+		}
+	}
+
 	if jsonPackage.LicenseConcluded == "" {
 		jsonPackage.LicenseConcluded = spdx.NOASSERTION
 	}

--- a/pkg/serialize/serialize.go
+++ b/pkg/serialize/serialize.go
@@ -167,15 +167,26 @@ func (json *JSON) buildJSONPackage(p *spdx.Package) (jsonPackage spdxJSON.Packag
 		}
 	}
 
-	if jsonPackage.LicenseConcluded == "" {
-		jsonPackage.LicenseConcluded = spdx.NOASSERTION
+	if spdxJSON.Version == "SPDX-2.2" {
+		if jsonPackage.LicenseConcluded == "" {
+			jsonPackage.LicenseConcluded = spdx.NOASSERTION
+		}
+		if jsonPackage.LicenseDeclared == "" {
+			jsonPackage.LicenseDeclared = spdx.NOASSERTION
+		}
+	} else {
+		if jsonPackage.LicenseConcluded == spdx.NOASSERTION {
+			jsonPackage.LicenseConcluded = ""
+		}
+		if jsonPackage.LicenseDeclared == spdx.NOASSERTION {
+			jsonPackage.LicenseDeclared = ""
+		}
 	}
-	if jsonPackage.LicenseDeclared == "" {
-		jsonPackage.LicenseDeclared = spdx.NOASSERTION
-	}
+
 	if jsonPackage.CopyrightText == "" {
 		jsonPackage.CopyrightText = spdx.NOASSERTION
 	}
+
 	if jsonPackage.DownloadLocation == "" {
 		jsonPackage.DownloadLocation = spdx.NONE
 	}
@@ -221,12 +232,21 @@ func (json *JSON) buildJSONFile(f *spdx.File) (jsonFile spdxJSON.File, err error
 		LicenseInfoInFile: []string{f.LicenseInfoInFile},
 		Checksums:         []spdxJSON.Checksum{},
 	}
-	if jsonFile.LicenseConcluded == "" {
-		jsonFile.LicenseConcluded = spdx.NOASSERTION
+
+	if spdxJSON.Version == "SPDX-2.2" {
+		if jsonFile.LicenseConcluded == "" {
+			jsonFile.LicenseConcluded = spdx.NOASSERTION
+		}
+	} else {
+		if jsonFile.LicenseConcluded == spdx.NOASSERTION {
+			jsonFile.LicenseConcluded = ""
+		}
 	}
+
 	if jsonFile.CopyrightText == "" {
 		jsonFile.CopyrightText = spdx.NOASSERTION
 	}
+
 	for algo, value := range f.Checksum {
 		jsonFile.Checksums = append(jsonFile.Checksums, spdxJSON.Checksum{
 			Algorithm: algo,

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -1007,11 +1007,16 @@ func (di *spdxDefaultImplementation) PackageFromDirectory(opts *Options, dirPath
 			err = fmt.Errorf("scanning file for license: %w", err)
 			return
 		}
+
+		// If a file does not contain a license then we assume
+		// the whole repository license applies. If it has one,
+		// the we conclude that files is released under those licenses.
 		f.LicenseInfoInFile = NONE
 		if lic == nil {
 			f.LicenseConcluded = licenseTag
 		} else {
 			f.LicenseInfoInFile = lic.LicenseID
+			f.LicenseConcluded = lic.LicenseID
 		}
 
 		if err = f.ReadSourceFile(filepath.Join(dirPath, path)); err != nil {

--- a/pkg/spdx/json/v2.2/types.go
+++ b/pkg/spdx/json/v2.2/types.go
@@ -88,34 +88,40 @@ func (c *CreationInfo) GetLicenseListVersion() string { return c.LicenseListVers
 func (c *CreationInfo) GetCreated() string            { return c.Created }
 
 type Package struct {
-	ID                   string                  `json:"SPDXID"`
-	Name                 string                  `json:"name"`
-	Version              string                  `json:"versionInfo"`
-	FilesAnalyzed        bool                    `json:"filesAnalyzed"`
-	LicenseDeclared      string                  `json:"licenseDeclared"`
-	LicenseConcluded     string                  `json:"licenseConcluded"`
-	Description          string                  `json:"description,omitempty"`
-	DownloadLocation     string                  `json:"downloadLocation"`
-	Originator           string                  `json:"originator,omitempty"`
-	SourceInfo           string                  `json:"sourceInfo,omitempty"`
-	CopyrightText        string                  `json:"copyrightText"`
-	HasFiles             []string                `json:"hasFiles,omitempty"`
-	LicenseInfoFromFiles []string                `json:"licenseInfoFromFiles,omitempty"`
-	Checksums            []Checksum              `json:"checksums"`
-	ExternalRefs         []ExternalRef           `json:"externalRefs,omitempty"`
-	VerificationCode     PackageVerificationCode `json:"packageVerificationCode,omitempty"`
+	ID                   string                   `json:"SPDXID"`
+	Name                 string                   `json:"name"`
+	Version              string                   `json:"versionInfo"`
+	FilesAnalyzed        bool                     `json:"filesAnalyzed"`
+	LicenseDeclared      string                   `json:"licenseDeclared"`
+	LicenseConcluded     string                   `json:"licenseConcluded"`
+	Description          string                   `json:"description,omitempty"`
+	DownloadLocation     string                   `json:"downloadLocation"`
+	Originator           string                   `json:"originator,omitempty"`
+	SourceInfo           string                   `json:"sourceInfo,omitempty"`
+	CopyrightText        string                   `json:"copyrightText"`
+	HasFiles             []string                 `json:"hasFiles,omitempty"`
+	LicenseInfoFromFiles []string                 `json:"licenseInfoFromFiles,omitempty"`
+	Checksums            []Checksum               `json:"checksums"`
+	ExternalRefs         []ExternalRef            `json:"externalRefs,omitempty"`
+	VerificationCode     *PackageVerificationCode `json:"packageVerificationCode,omitempty"`
 }
 
-func (p *Package) GetID() string                                         { return p.ID }
-func (p *Package) GetName() string                                       { return p.Name }
-func (p *Package) GetDownloadLocation() string                           { return p.DownloadLocation }
-func (p *Package) GetCopyrightText() string                              { return p.CopyrightText }
-func (p *Package) GetLicenseConcluded() string                           { return p.LicenseConcluded }
-func (p *Package) GetFilesAnalyzed() bool                                { return p.FilesAnalyzed }
-func (p *Package) GetLicenseDeclared() string                            { return p.LicenseDeclared }
-func (p *Package) GetVersion() string                                    { return p.Version }
-func (p *Package) GetVerificationCode() document.PackageVerificationCode { return &p.VerificationCode }
-func (p *Package) GetPrimaryPurpose() string                             { return "" }
+func (p *Package) GetID() string               { return p.ID }
+func (p *Package) GetName() string             { return p.Name }
+func (p *Package) GetDownloadLocation() string { return p.DownloadLocation }
+func (p *Package) GetCopyrightText() string    { return p.CopyrightText }
+func (p *Package) GetLicenseConcluded() string { return p.LicenseConcluded }
+func (p *Package) GetFilesAnalyzed() bool      { return p.FilesAnalyzed }
+func (p *Package) GetLicenseDeclared() string  { return p.LicenseDeclared }
+func (p *Package) GetVersion() string          { return p.Version }
+func (p *Package) GetPrimaryPurpose() string   { return "" }
+
+func (p *Package) GetVerificationCode() document.PackageVerificationCode {
+	if p.VerificationCode == nil {
+		return &PackageVerificationCode{}
+	}
+	return p.VerificationCode
+}
 
 func (p *Package) GetChecksums() []document.Checksum {
 	checksums := make([]document.Checksum, len(p.Checksums))

--- a/pkg/spdx/json/v2.3/types.go
+++ b/pkg/spdx/json/v2.3/types.go
@@ -155,7 +155,7 @@ type File struct {
 	LicenseConcluded  string     `json:"licenseConcluded,omitempty"`
 	Description       string     `json:"description,omitempty"`
 	FileTypes         []string   `json:"fileTypes,omitempty"`
-	LicenseInfoInFile []string   `json:"licenseInfoInFiles"` // List of licenses
+	LicenseInfoInFile []string   `json:"licenseInfoInFiles,omitempty"` // List of licenses
 	Checksums         []Checksum `json:"checksums"`
 }
 

--- a/pkg/spdx/json/v2.3/types.go
+++ b/pkg/spdx/json/v2.3/types.go
@@ -88,35 +88,41 @@ func (c *CreationInfo) GetLicenseListVersion() string { return c.LicenseListVers
 func (c *CreationInfo) GetCreated() string            { return c.Created }
 
 type Package struct {
-	ID                   string                  `json:"SPDXID"`
-	Name                 string                  `json:"name"`
-	Version              string                  `json:"versionInfo"`
-	FilesAnalyzed        bool                    `json:"filesAnalyzed"`
-	LicenseDeclared      string                  `json:"licenseDeclared"`
-	LicenseConcluded     string                  `json:"licenseConcluded"`
-	Description          string                  `json:"description,omitempty"`
-	DownloadLocation     string                  `json:"downloadLocation"`
-	Originator           string                  `json:"originator,omitempty"`
-	SourceInfo           string                  `json:"sourceInfo,omitempty"`
-	CopyrightText        string                  `json:"copyrightText"`
-	PrimaryPurpose       string                  `json:"primaryPackagePurpose,omitempty"`
-	HasFiles             []string                `json:"hasFiles,omitempty"`
-	LicenseInfoFromFiles []string                `json:"licenseInfoFromFiles,omitempty"`
-	Checksums            []Checksum              `json:"checksums"`
-	ExternalRefs         []ExternalRef           `json:"externalRefs,omitempty"`
-	VerificationCode     PackageVerificationCode `json:"packageVerificationCode,omitempty"`
+	ID                   string                   `json:"SPDXID"`
+	Name                 string                   `json:"name"`
+	Version              string                   `json:"versionInfo"`
+	FilesAnalyzed        bool                     `json:"filesAnalyzed"`
+	LicenseDeclared      string                   `json:"licenseDeclared"`
+	LicenseConcluded     string                   `json:"licenseConcluded"`
+	Description          string                   `json:"description,omitempty"`
+	DownloadLocation     string                   `json:"downloadLocation"`
+	Originator           string                   `json:"originator,omitempty"`
+	SourceInfo           string                   `json:"sourceInfo,omitempty"`
+	CopyrightText        string                   `json:"copyrightText"`
+	PrimaryPurpose       string                   `json:"primaryPackagePurpose,omitempty"`
+	HasFiles             []string                 `json:"hasFiles,omitempty"`
+	LicenseInfoFromFiles []string                 `json:"licenseInfoFromFiles,omitempty"`
+	Checksums            []Checksum               `json:"checksums"`
+	ExternalRefs         []ExternalRef            `json:"externalRefs,omitempty"`
+	VerificationCode     *PackageVerificationCode `json:"packageVerificationCode,omitempty"`
 }
 
-func (p *Package) GetID() string                                         { return p.ID }
-func (p *Package) GetName() string                                       { return p.Name }
-func (p *Package) GetDownloadLocation() string                           { return p.DownloadLocation }
-func (p *Package) GetCopyrightText() string                              { return p.CopyrightText }
-func (p *Package) GetLicenseConcluded() string                           { return p.LicenseConcluded }
-func (p *Package) GetFilesAnalyzed() bool                                { return p.FilesAnalyzed }
-func (p *Package) GetLicenseDeclared() string                            { return p.LicenseDeclared }
-func (p *Package) GetVersion() string                                    { return p.Version }
-func (p *Package) GetVerificationCode() document.PackageVerificationCode { return &p.VerificationCode }
-func (p *Package) GetPrimaryPurpose() string                             { return p.PrimaryPurpose }
+func (p *Package) GetID() string               { return p.ID }
+func (p *Package) GetName() string             { return p.Name }
+func (p *Package) GetDownloadLocation() string { return p.DownloadLocation }
+func (p *Package) GetCopyrightText() string    { return p.CopyrightText }
+func (p *Package) GetLicenseConcluded() string { return p.LicenseConcluded }
+func (p *Package) GetFilesAnalyzed() bool      { return p.FilesAnalyzed }
+func (p *Package) GetLicenseDeclared() string  { return p.LicenseDeclared }
+func (p *Package) GetVersion() string          { return p.Version }
+func (p *Package) GetPrimaryPurpose() string   { return p.PrimaryPurpose }
+
+func (p *Package) GetVerificationCode() document.PackageVerificationCode {
+	if p.VerificationCode == nil {
+		return &PackageVerificationCode{}
+	}
+	return p.VerificationCode
+}
 
 func (p *Package) GetChecksums() []document.Checksum {
 	checksums := make([]document.Checksum, len(p.Checksums))
@@ -135,7 +141,7 @@ func (p *Package) GetExternalRefs() []document.ExternalRef {
 }
 
 type PackageVerificationCode struct {
-	Value         string   `json:"packageVerificationCodeValue"`
+	Value         string   `json:"packageVerificationCodeValue,omitempty"`
 	ExcludedFiles []string `json:"packageVerificationCodeExcludedFiles,omitempty"`
 }
 

--- a/pkg/spdx/json/v2.3/types.go
+++ b/pkg/spdx/json/v2.3/types.go
@@ -92,8 +92,8 @@ type Package struct {
 	Name                 string                   `json:"name"`
 	Version              string                   `json:"versionInfo"`
 	FilesAnalyzed        bool                     `json:"filesAnalyzed"`
-	LicenseDeclared      string                   `json:"licenseDeclared"`
-	LicenseConcluded     string                   `json:"licenseConcluded"`
+	LicenseDeclared      string                   `json:"licenseDeclared,omitempty"`
+	LicenseConcluded     string                   `json:"licenseConcluded,omitempty"`
 	Description          string                   `json:"description,omitempty"`
 	DownloadLocation     string                   `json:"downloadLocation"`
 	Originator           string                   `json:"originator,omitempty"`
@@ -152,7 +152,7 @@ type File struct {
 	Name              string     `json:"fileName"`
 	CopyrightText     string     `json:"copyrightText"`
 	NoticeText        string     `json:"noticeText,omitempty"`
-	LicenseConcluded  string     `json:"licenseConcluded"`
+	LicenseConcluded  string     `json:"licenseConcluded,omitempty"`
 	Description       string     `json:"description,omitempty"`
 	FileTypes         []string   `json:"fileTypes,omitempty"`
 	LicenseInfoInFile []string   `json:"licenseInfoInFiles"` // List of licenses


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:


A number of fields in the SPDX 2.3 spec are now optional and allow for less verbose SBOMs when not needed. This PR makes the license fields and package verification `omitempty`able to remove non-required fillds from the final document.

It also improves how we specify the concluded license in files: When the license scanner picks up a license _inside_ a file (ie in the copyright boilerplate) it will now be listed in the licenseConcluded field as it should be.

#### Which issue(s) this PR fixes:

Fixes #230 

#### Special notes for your reviewer:

While writing this PR I may have stumbled upon a type on the SPDX JSON schema. Opened https://github.com/spdx/spdx-spec/issues/842 to check.

#### Does this PR introduce a user-facing change?

```release-note
- licenseDeclared in packages and licenseConcluded in files and packages will now be omitted in SPDX 2.3 documents.
- [API Change] the `PackageVerificationCode` in the package JSON types (both in 2.2 and 2.3) has been changed and is now a pointer. This is a breaking change for anything depending on the bom types. This fixes a bug where JSON SBOMs contained an empty package verification code struct.
-  licenseInfoInFile in both packages and files is now committed from the JSON output when empty.

```
