### PR TITLE
Detect recursion loop in spdx.recursiveIDSearch

### DIFF
--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -271,12 +271,14 @@ func recursiveIDSearch(id string, o Object, seen *map[string]struct{}) Object {
 	if o.SPDXID() == id {
 		return o
 	}
+
+	if _, ok := (*seen)[o.SPDXID()]; ok {
+		return nil
+	}
+	(*seen)[o.SPDXID()] = struct{}{}
+
 	for _, rel := range *o.GetRelationships() {
 		if rel.Peer == nil {
-			continue
-		}
-
-		if _, ok := (*seen)[o.SPDXID()]; ok {
 			continue
 		}
 


### PR DESCRIPTION

/kind bug

#### What this PR does / why we need it:

This commit fixes a bug in the `recursiveIDSearch()` function of the SPDX package to detect recursion loops when searching for SPDX IDs. This fixes a bug where bom would panic when generating an image with an image and a file.


#### Which issue(s) this PR fixes:

Fixes #240

#### Special notes for your reviewer:

/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
Fixed a recursion loop in `spdx.recursiveIDSearch` which lead to panics when generating sboms describing multiple artifacts.
```
