### PR TITLE
Make license list version configurable

### DIFF
--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"sigs.k8s.io/bom/pkg/license"
 	"sigs.k8s.io/bom/pkg/serialize"
 	"sigs.k8s.io/bom/pkg/spdx"
 	"sigs.k8s.io/release-utils/util"
@@ -43,6 +44,7 @@ type generateOptions struct {
 	outputFile     string
 	configFile     string
 	license        string
+	licenseListVer string
 	provenancePath string // Path to export the SBOM as provenance statement
 	images         []string
 	imageArchives  []string
@@ -296,6 +298,13 @@ completed by a later stage in your CI/CD pipeline. See the
 		"name for the document, in contrast to URLs, intended for humans",
 	)
 
+	generateCmd.PersistentFlags().StringVar(
+		&genOpts.licenseListVer,
+		"license-list-version",
+		license.DefaultCatalogOpts.Version,
+		"version of the SPDX list to use, use 'latest' to download the latest",
+	)
+
 	if err := generateCmd.MarkPersistentFlagDirname("dirs"); err != nil {
 		logrus.Error("error marking flag as directory")
 	}
@@ -317,21 +326,22 @@ func generateBOM(opts *generateOptions) error {
 	newDocBuilderOpts := []spdx.NewDocBuilderOption{spdx.WithFormat(spdx.Format(opts.format))}
 	builder := spdx.NewDocBuilder(newDocBuilderOpts...)
 	builderOpts := &spdx.DocGenerateOptions{
-		Tarballs:         opts.imageArchives,
-		Archives:         opts.archives,
-		Files:            opts.files,
-		Images:           opts.images,
-		Directories:      opts.directories,
-		Format:           opts.format,
-		OutputFile:       opts.outputFile,
-		Namespace:        opts.namespace,
-		AnalyseLayers:    opts.analyze,
-		ProcessGoModules: !opts.noGoModules,
-		OnlyDirectDeps:   !opts.noGoTransient,
-		ConfigFile:       opts.configFile,
-		License:          opts.license,
-		ScanImages:       opts.scanImages,
-		Name:             opts.name,
+		Tarballs:           opts.imageArchives,
+		Archives:           opts.archives,
+		Files:              opts.files,
+		Images:             opts.images,
+		Directories:        opts.directories,
+		Format:             opts.format,
+		OutputFile:         opts.outputFile,
+		Namespace:          opts.namespace,
+		AnalyseLayers:      opts.analyze,
+		ProcessGoModules:   !opts.noGoModules,
+		OnlyDirectDeps:     !opts.noGoTransient,
+		ConfigFile:         opts.configFile,
+		License:            opts.license,
+		LicenseListVersion: opts.licenseListVer,
+		ScanImages:         opts.scanImages,
+		Name:               opts.name,
 	}
 
 	// We only replace the ignore patterns one or more where defined

--- a/pkg/license/catalog.go
+++ b/pkg/license/catalog.go
@@ -31,16 +31,25 @@ import (
 // CatalogOptions are the spdx settings
 type CatalogOptions struct {
 	CacheDir string // Directrory to catch the license we download from SPDX.org
+	Version  string // Version of the licenses to download  (eg v3.19) or blank for latest
 }
 
 // DefaultCatalogOpts are the predetermined settings. License and cache directories
-// are in the temporary OS directory and are created if the do not exist
-var DefaultCatalogOpts = &CatalogOptions{}
+// are in the temporary OS directory and are created if the do not exist.
+//
+// The version included here is hardcoded and is intended to be the latest. The
+// plan is to embed in the bom binary the latest SPDX license list which should
+// match this entry always. See the following issue for details of this feature:
+// https://github.com/kubernetes-sigs/bom/issues/44
+var DefaultCatalogOpts = &CatalogOptions{
+	Version: "v3.20",
+}
 
 // NewCatalogWithOptions returns a SPDX object with the specified options
 func NewCatalogWithOptions(opts *CatalogOptions) (catalog *Catalog, err error) {
 	// Create the license downloader
 	doptions := DefaultDownloaderOpts
+	doptions.Version = opts.Version
 	doptions.CacheDir = opts.CacheDir
 	downloader, err := NewDownloaderWithOptions(doptions)
 	if err != nil {

--- a/pkg/license/implementation.go
+++ b/pkg/license/implementation.go
@@ -181,6 +181,8 @@ func (d *ReaderDefaultImpl) Initialize(opts *ReaderOptions) error {
 	// Create the implementation's SPDX object
 	catalogOpts := DefaultCatalogOpts
 	catalogOpts.CacheDir = opts.CachePath()
+	catalogOpts.Version = opts.LicenseListVersion
+
 	catalog, err := NewCatalogWithOptions(catalogOpts)
 	if err != nil {
 		return fmt.Errorf("creating SPDX object: %w", err)

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -105,6 +105,7 @@ type ReaderOptions struct {
 	WorkDir             string  // Directory where the reader will store its data
 	CacheDir            string  // Optional directory where the reader will store its downloads cache
 	LicenseDir          string  // Optional dir to store and read the SPDX licenses from
+	LicenseListVersion  string  // Version of the SPDX license list to use
 }
 
 // Validate checks the options to verify the are sane

--- a/pkg/serialize/serialize.go
+++ b/pkg/serialize/serialize.go
@@ -60,7 +60,7 @@ func (json *JSON) Serialize(doc *spdx.Document) (string, error) {
 			Creators: []string{
 				fmt.Sprintf("Tool: %s-%s", "bom", version.GetVersionInfo().GitVersion),
 			},
-			LicenseListVersion: "",
+			LicenseListVersion: doc.LicenseListVersion,
 		},
 		DataLicense:       doc.DataLicense,
 		Namespace:         doc.Namespace,

--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -22,11 +22,13 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
+	"sigs.k8s.io/bom/pkg/license"
 	"sigs.k8s.io/release-utils/util"
 )
 
@@ -192,6 +194,10 @@ func (builder *defaultDocBuilderImpl) GenerateDoc(
 	// Create the new document
 	doc = NewDocument()
 	doc.Name = genopts.Name
+	doc.LicenseListVersion = strings.TrimPrefix(license.DefaultCatalogOpts.Version, "v")
+	if genopts.LicenseListVersion != "" {
+		doc.LicenseListVersion = strings.TrimPrefix(genopts.LicenseListVersion, "v")
+	}
 
 	// If we do not have a namespace, we generate one
 	// under the public SPDX URL defined in the spec.

--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -22,13 +22,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
-
-	"sigs.k8s.io/bom/pkg/license"
 	"sigs.k8s.io/release-utils/util"
 )
 
@@ -81,24 +75,56 @@ func NewDocBuilder(options ...NewDocBuilderOption) *DocBuilder {
 	return db
 }
 
-// DocBuilder is a tool to write spdx manifests
+// DocBuilder is a tool to write SPDX SBOMs. It is configurable by
+// defining values in its DocBuilderOptions. Options to customize the
+// generated document are passed to the Generate() method in DocGenerateOptions
+// struct.
 type DocBuilder struct {
 	options *DocBuilderOptions
 	impl    DocBuilderImplementation
 }
 
-// Generate creates anew SPDX document describing the artifacts specified in the options
+// Generate creates a new SPDX SBOM. The resulting document will describe the all
+// artifacts specified in the DocGenerateOptions struct passed.
 func (db *DocBuilder) Generate(genopts *DocGenerateOptions) (*Document, error) {
-	if genopts.ConfigFile != "" {
-		if err := db.impl.ReadYamlConfiguration(genopts.ConfigFile, genopts); err != nil {
-			return nil, fmt.Errorf("parsing configuration file: %w", err)
-		}
+	if err := db.impl.ReadYamlConfiguration(genopts.ConfigFile, genopts); err != nil {
+		return nil, fmt.Errorf("parsing configuration file: %w", err)
 	}
-	// Create the SPDX document
-	doc, err := db.impl.GenerateDoc(db.options, genopts)
+
+	if err := db.impl.ValidateOptions(genopts); err != nil {
+		return nil, fmt.Errorf("checking build options: %w", err)
+	}
+
+	spdx, err := db.impl.CreateSPDXClient(genopts, db.options)
 	if err != nil {
-		return nil, fmt.Errorf("creating SPDX document: %w", err)
+		return nil, fmt.Errorf("generating spdx client")
 	}
+
+	doc, err := db.impl.CreateDocument(genopts, spdx)
+	if err != nil {
+		return nil, fmt.Errorf("creating spdx document: %w", err)
+	}
+
+	if err := db.impl.ScanDirectories(genopts, spdx, doc); err != nil {
+		return nil, fmt.Errorf("scanning directories: %w", err)
+	}
+
+	if err := db.impl.ScanImages(genopts, spdx, doc); err != nil {
+		return nil, fmt.Errorf("scanning images: %w", err)
+	}
+
+	if err := db.impl.ScanImageArchives(genopts, spdx, doc); err != nil {
+		return nil, fmt.Errorf("scanning image archives: %w", err)
+	}
+
+	if err := db.impl.ScanArchives(genopts, spdx, doc); err != nil {
+		return nil, fmt.Errorf("scanning archives: %w", err)
+	}
+
+	if err := db.impl.ScanFiles(genopts, spdx, doc); err != nil {
+		return nil, fmt.Errorf("scanning files: %w", err)
+	}
+
 	return doc, nil
 }
 
@@ -156,158 +182,6 @@ var defaultDocBuilderOpts = DocBuilderOptions{
 	WorkDir: filepath.Join(os.TempDir(), "spdx-docbuilder"),
 }
 
-type DocBuilderImplementation interface {
-	GenerateDoc(*DocBuilderOptions, *DocGenerateOptions) (*Document, error)
-	WriteDoc(*Document, string) error
-	ReadYamlConfiguration(string, *DocGenerateOptions) error
-}
-
-// defaultDocBuilderImpl is the default implementation for the
-// SPDX document builder
-type defaultDocBuilderImpl struct {
-	format Format
-}
-
-// Generate generates a document
-func (builder *defaultDocBuilderImpl) GenerateDoc(
-	opts *DocBuilderOptions, genopts *DocGenerateOptions,
-) (doc *Document, err error) {
-	if err := genopts.Validate(); err != nil {
-		return nil, fmt.Errorf("checking build options: %w", err)
-	}
-
-	spdx := NewSPDX()
-	if len(genopts.IgnorePatterns) > 0 {
-		spdx.Options().IgnorePatterns = genopts.IgnorePatterns
-	}
-	spdx.Options().AnalyzeLayers = genopts.AnalyseLayers
-	spdx.Options().ProcessGoModules = genopts.ProcessGoModules
-	spdx.Options().ScanImages = genopts.ScanImages
-	spdx.Options().LicenseListVersion = genopts.LicenseListVersion
-
-	if !util.Exists(opts.WorkDir) {
-		if err := os.MkdirAll(opts.WorkDir, os.FileMode(0o755)); err != nil {
-			return nil, fmt.Errorf("creating builder worskpace dir: %w", err)
-		}
-	}
-
-	// Create the new document
-	doc = NewDocument()
-	doc.Name = genopts.Name
-	doc.LicenseListVersion = strings.TrimPrefix(license.DefaultCatalogOpts.Version, "v")
-	if genopts.LicenseListVersion != "" {
-		doc.LicenseListVersion = strings.TrimPrefix(genopts.LicenseListVersion, "v")
-	}
-
-	// If we do not have a namespace, we generate one
-	// under the public SPDX URL defined in the spec.
-	// (ref https://spdx.github.io/spdx-spec/document-creation-information/#65-spdx-document-namespace-field)
-	if genopts.Namespace == "" {
-		doc.Namespace = "https://spdx.org/spdxdocs/k8s-releng-bom-" + uuid.NewString()
-	} else {
-		doc.Namespace = genopts.Namespace
-	}
-	doc.Creator.Person = genopts.CreatorPerson
-	doc.ExternalDocRefs = genopts.ExternalDocumentRef
-
-	for _, dirPattern := range genopts.Directories {
-		matches, err := filepath.Glob(dirPattern)
-		if err != nil {
-			return nil, err
-		}
-		for _, dirMatch := range matches {
-			isFile, err := pathIsOfFile(dirMatch)
-			if err != nil {
-				return nil, fmt.Errorf("stat dir: %w", err)
-			}
-			if isFile {
-				logrus.Debugf("Skipping %s because it's a file", dirMatch)
-				continue
-			}
-			logrus.Infof("Processing directory %s", dirMatch)
-			pkg, err := spdx.PackageFromDirectory(dirMatch)
-			if err != nil {
-				return nil, fmt.Errorf("generating package from directory: %w", err)
-			}
-			doc.ensureUniqueElementID(pkg)
-			if err := doc.AddPackage(pkg); err != nil {
-				return nil, fmt.Errorf("adding directory package to document: %w", err)
-			}
-		}
-	}
-
-	// Process all image references from registries
-	for _, i := range genopts.Images {
-		logrus.Infof("Processing image reference: %s", i)
-		p, err := spdx.ImageRefToPackage(i)
-		if err != nil {
-			return nil, fmt.Errorf("generating SPDX package from image ref %s: %w", i, err)
-		}
-		doc.ensureUniqueElementID(p)
-		doc.ensureUniquePeerIDs(p.GetRelationships())
-		if err := doc.AddPackage(p); err != nil {
-			return nil, fmt.Errorf("adding package to document: %w", err)
-		}
-	}
-
-	// Process OCI image archives
-	for _, tb := range genopts.Tarballs {
-		logrus.Infof("Processing image archive %s", tb)
-		p, err := spdx.PackageFromImageTarball(tb)
-		if err != nil {
-			return nil, fmt.Errorf("generating tarball package: %w", err)
-		}
-		doc.ensureUniqueElementID(p)
-		doc.ensureUniquePeerIDs(p.GetRelationships())
-		if err := doc.AddPackage(p); err != nil {
-			return nil, fmt.Errorf("adding package to document: %w", err)
-		}
-	}
-
-	// Add archive files as packages
-	for _, tf := range genopts.Archives {
-		logrus.Infof("Adding archive file as package: %s", tf)
-		p, err := spdx.PackageFromArchive(tf)
-		if err != nil {
-			return nil, fmt.Errorf("creating spdx package from archive: %w", err)
-		}
-		doc.ensureUniqueElementID(p)
-		doc.ensureUniquePeerIDs(p.GetRelationships())
-		if err := doc.AddPackage(p); err != nil {
-			return nil, fmt.Errorf("adding package to document: %w", err)
-		}
-	}
-
-	// Process single files, not part of a package
-	for _, filePattern := range genopts.Files {
-		matches, err := filepath.Glob(filePattern)
-		if err != nil {
-			return nil, err
-		}
-		if len(matches) == 0 {
-			logrus.Warnf("%s pattern didn't match any file", filePattern)
-		}
-		for _, filePath := range matches {
-			isFile, err := pathIsOfFile(filePath)
-			if err != nil {
-				return nil, fmt.Errorf("stat file: %w", err)
-			}
-			if !isFile {
-				continue
-			}
-			f, err := spdx.FileFromPath(filePath)
-			if err != nil {
-				return nil, fmt.Errorf("adding file: %w", err)
-			}
-			doc.ensureUniqueElementID(f)
-			if err := doc.AddFile(f); err != nil {
-				return nil, fmt.Errorf("adding file to document: %w", err)
-			}
-		}
-	}
-	return doc, nil
-}
-
 // TODO: Move this to https://github.com/kubernetes-sigs/release-utils/blob/main/util/common.go#L485
 func pathIsOfFile(path string) (bool, error) {
 	fInfo, err := os.Stat(path)
@@ -315,74 +189,4 @@ func pathIsOfFile(path string) (bool, error) {
 		return false, err
 	}
 	return !fInfo.IsDir(), nil
-}
-
-// WriteDoc renders the document to a file
-func (builder *defaultDocBuilderImpl) WriteDoc(doc *Document, path string) error {
-	markup, err := doc.Render()
-	if err != nil {
-		return fmt.Errorf("generating document markup: %w", err)
-	}
-	logrus.Infof("writing document to %s", path)
-
-	if err := os.WriteFile(path, []byte(markup), os.FileMode(0o644)); err != nil {
-		return fmt.Errorf(
-			"writing document markup to file: %w",
-			err,
-		)
-	}
-	return nil
-}
-
-// ReadYamlConfiguration reads a yaml configuration and
-// set the values in an options struct
-func (builder *defaultDocBuilderImpl) ReadYamlConfiguration(
-	path string, opts *DocGenerateOptions,
-) (err error) {
-	yamldata, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("reading yaml SBOM configuration: %w", err)
-	}
-
-	conf := &YamlBOMConfiguration{}
-	if err := yaml.Unmarshal(yamldata, conf); err != nil {
-		return fmt.Errorf("unmarshalling SBOM configuration YAML: %w", err)
-	}
-
-	if conf.Name != "" {
-		opts.Name = conf.Name
-	}
-
-	if conf.Namespace != "" {
-		opts.Namespace = conf.Namespace
-	}
-
-	if conf.Creator.Person != "" {
-		opts.CreatorPerson = conf.Creator.Person
-	}
-
-	if conf.License != "" {
-		opts.License = conf.License
-	}
-
-	opts.ExternalDocumentRef = conf.ExternalDocRefs
-
-	// Add all the artifacts
-	for _, artifact := range conf.Artifacts {
-		logrus.Infof("Configuration has artifact of type %s: %s", artifact.Type, artifact.Source)
-		switch artifact.Type {
-		case "directory":
-			opts.Directories = append(opts.Directories, artifact.Source)
-		case "image":
-			opts.Images = append(opts.Images, artifact.Source)
-		case "docker-archive":
-			opts.Tarballs = append(opts.Tarballs, artifact.Source)
-		case "file":
-			opts.Files = append(opts.Files, artifact.Source)
-		case "archive":
-			opts.Archives = append(opts.Archives, artifact.Source)
-		}
-	}
-
-	return nil
 }

--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -114,6 +114,7 @@ type DocGenerateOptions struct {
 	Namespace           string                // Namespace for the document (a unique URI)
 	CreatorPerson       string                // Document creator information
 	License             string                // Main license of the document
+	LicenseListVersion  string                // Version of the SPDX list to use
 	Tarballs            []string              // A slice of docker archives (tar)
 	Archives            []string              // A list of archive files to add as packages
 	Files               []string              // A slice of naked files to include in the bom
@@ -180,6 +181,7 @@ func (builder *defaultDocBuilderImpl) GenerateDoc(
 	spdx.Options().AnalyzeLayers = genopts.AnalyseLayers
 	spdx.Options().ProcessGoModules = genopts.ProcessGoModules
 	spdx.Options().ScanImages = genopts.ScanImages
+	spdx.Options().LicenseListVersion = genopts.LicenseListVersion
 
 	if !util.Exists(opts.WorkDir) {
 		if err := os.MkdirAll(opts.WorkDir, os.FileMode(0o755)); err != nil {

--- a/pkg/spdx/builder_implementation.go
+++ b/pkg/spdx/builder_implementation.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdx
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/bom/pkg/license"
+	"sigs.k8s.io/release-utils/util"
+)
+
+type DocBuilderImplementation interface {
+	WriteDoc(*Document, string) error
+	ReadYamlConfiguration(string, *DocGenerateOptions) error
+	CreateSPDXClient(*DocGenerateOptions, *DocBuilderOptions) (*SPDX, error)
+	ValidateOptions(*DocGenerateOptions) error
+
+	// Document generation functions
+	CreateDocument(*DocGenerateOptions, *SPDX) (*Document, error)
+	ScanDirectories(*DocGenerateOptions, *SPDX, *Document) error
+	ScanImages(*DocGenerateOptions, *SPDX, *Document) error
+	ScanImageArchives(*DocGenerateOptions, *SPDX, *Document) error
+	ScanArchives(*DocGenerateOptions, *SPDX, *Document) error
+	ScanFiles(*DocGenerateOptions, *SPDX, *Document) error
+}
+
+// defaultDocBuilderImpl is the default implementation for the
+// SPDX document builder
+type defaultDocBuilderImpl struct {
+	format Format
+}
+
+func (builder *defaultDocBuilderImpl) CreateDocument(genopts *DocGenerateOptions, spdx *SPDX) (*Document, error) {
+	// Create the new document
+	doc := NewDocument()
+	doc.Name = genopts.Name
+	doc.LicenseListVersion = strings.TrimPrefix(license.DefaultCatalogOpts.Version, "v")
+	if genopts.LicenseListVersion != "" {
+		doc.LicenseListVersion = strings.TrimPrefix(genopts.LicenseListVersion, "v")
+	}
+
+	// If we do not have a namespace, we generate one under the public SPDX
+	// URL as defined in the spec.
+	// (ref https://spdx.github.io/spdx-spec/document-creation-information/#65-spdx-document-namespace-field)
+	doc.Namespace = genopts.Namespace
+	if genopts.Namespace == "" {
+		doc.Namespace = "https://spdx.org/spdxdocs/k8s-releng-bom-" + uuid.NewString()
+	}
+
+	doc.Creator.Person = genopts.CreatorPerson
+	doc.ExternalDocRefs = genopts.ExternalDocumentRef
+	return doc, nil
+}
+
+func (builder *defaultDocBuilderImpl) CreateSPDXClient(genopts *DocGenerateOptions, opts *DocBuilderOptions) (*SPDX, error) {
+	spdx := NewSPDX()
+	if len(genopts.IgnorePatterns) > 0 {
+		spdx.Options().IgnorePatterns = genopts.IgnorePatterns
+	}
+	spdx.Options().AnalyzeLayers = genopts.AnalyseLayers
+	spdx.Options().ProcessGoModules = genopts.ProcessGoModules
+	spdx.Options().ScanImages = genopts.ScanImages
+	spdx.Options().LicenseListVersion = genopts.LicenseListVersion
+
+	if !util.Exists(opts.WorkDir) {
+		if err := os.MkdirAll(opts.WorkDir, os.FileMode(0o755)); err != nil {
+			return nil, fmt.Errorf("creating builder worskpace dir: %w", err)
+		}
+	}
+	return spdx, nil
+}
+
+func (builder *defaultDocBuilderImpl) ScanDirectories(genopts *DocGenerateOptions, spdx *SPDX, doc *Document) error {
+	for _, dirPattern := range genopts.Directories {
+		matches, err := filepath.Glob(dirPattern)
+		if err != nil {
+			return fmt.Errorf("globbing directory pattern: %w", err)
+		}
+		for _, dirMatch := range matches {
+			isFile, err := pathIsOfFile(dirMatch)
+			if err != nil {
+				return fmt.Errorf("stat dir: %w", err)
+			}
+			if isFile {
+				logrus.Debugf("Skipping %s because it's a file", dirMatch)
+				continue
+			}
+			logrus.Infof("Processing directory %s", dirMatch)
+			pkg, err := spdx.PackageFromDirectory(dirMatch)
+			if err != nil {
+				return fmt.Errorf("generating package from directory: %w", err)
+			}
+			doc.ensureUniqueElementID(pkg)
+			if err := doc.AddPackage(pkg); err != nil {
+				return fmt.Errorf("adding directory package to document: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func (builder *defaultDocBuilderImpl) ScanImages(genopts *DocGenerateOptions, spdx *SPDX, doc *Document) error {
+	// Process all image references from registries
+	for _, i := range genopts.Images {
+		logrus.Infof("Processing image reference: %s", i)
+		p, err := spdx.ImageRefToPackage(i)
+		if err != nil {
+			return fmt.Errorf("generating SPDX package from image ref %s: %w", i, err)
+		}
+		doc.ensureUniqueElementID(p)
+		doc.ensureUniquePeerIDs(p.GetRelationships())
+		if err := doc.AddPackage(p); err != nil {
+			return fmt.Errorf("adding package to document: %w", err)
+		}
+	}
+	return nil
+}
+
+func (builder *defaultDocBuilderImpl) ScanImageArchives(genopts *DocGenerateOptions, spdx *SPDX, doc *Document) error {
+	// Process OCI image archives
+	for _, tb := range genopts.Tarballs {
+		logrus.Infof("Processing image archive %s", tb)
+		p, err := spdx.PackageFromImageTarball(tb)
+		if err != nil {
+			return fmt.Errorf("generating tarball package: %w", err)
+		}
+		doc.ensureUniqueElementID(p)
+		doc.ensureUniquePeerIDs(p.GetRelationships())
+		if err := doc.AddPackage(p); err != nil {
+			return fmt.Errorf("adding package to document: %w", err)
+		}
+	}
+	return nil
+}
+
+func (builder *defaultDocBuilderImpl) ScanArchives(genopts *DocGenerateOptions, spdx *SPDX, doc *Document) error {
+	// Add archive files as packages
+	for _, tf := range genopts.Archives {
+		logrus.Infof("Adding archive file as package: %s", tf)
+		p, err := spdx.PackageFromArchive(tf)
+		if err != nil {
+			return fmt.Errorf("creating spdx package from archive: %w", err)
+		}
+		doc.ensureUniqueElementID(p)
+		doc.ensureUniquePeerIDs(p.GetRelationships())
+		if err := doc.AddPackage(p); err != nil {
+			return fmt.Errorf("adding package to document: %w", err)
+		}
+	}
+	return nil
+}
+
+func (builder *defaultDocBuilderImpl) ScanFiles(genopts *DocGenerateOptions, spdx *SPDX, doc *Document) error {
+	// Process single files, not part of a package
+	for _, filePattern := range genopts.Files {
+		matches, err := filepath.Glob(filePattern)
+		if err != nil {
+			return fmt.Errorf("globing files from expression: %w", err)
+		}
+		if len(matches) == 0 {
+			logrus.Warnf("%s pattern didn't match any file", filePattern)
+		}
+		for _, filePath := range matches {
+			isFile, err := pathIsOfFile(filePath)
+			if err != nil {
+				return fmt.Errorf("stat file: %w", err)
+			}
+			if !isFile {
+				continue
+			}
+			f, err := spdx.FileFromPath(filePath)
+			if err != nil {
+				return fmt.Errorf("creating SPDX file: %w", err)
+			}
+			doc.ensureUniqueElementID(f)
+			if err := doc.AddFile(f); err != nil {
+				return fmt.Errorf("adding file to document: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// ReadYamlConfiguration reads a yaml configuration and
+// set the values in an options struct
+func (builder *defaultDocBuilderImpl) ReadYamlConfiguration(
+	path string, genopts *DocGenerateOptions,
+) (err error) {
+	// NOOP if no YAML file is specified
+	if path == "" {
+		return nil
+	}
+
+	yamldata, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading yaml SBOM configuration: %w", err)
+	}
+
+	conf := &YamlBOMConfiguration{}
+	if err := yaml.Unmarshal(yamldata, conf); err != nil {
+		return fmt.Errorf("unmarshalling SBOM configuration YAML: %w", err)
+	}
+
+	if conf.Name != "" {
+		genopts.Name = conf.Name
+	}
+
+	if conf.Namespace != "" {
+		genopts.Namespace = conf.Namespace
+	}
+
+	if conf.Creator.Person != "" {
+		genopts.CreatorPerson = conf.Creator.Person
+	}
+
+	if conf.License != "" {
+		genopts.License = conf.License
+	}
+
+	genopts.ExternalDocumentRef = conf.ExternalDocRefs
+
+	// Add all the artifacts
+	for _, artifact := range conf.Artifacts {
+		logrus.Infof("Configuration has artifact of type %s: %s", artifact.Type, artifact.Source)
+		switch artifact.Type {
+		case "directory":
+			genopts.Directories = append(genopts.Directories, artifact.Source)
+		case "image":
+			genopts.Images = append(genopts.Images, artifact.Source)
+		case "docker-archive":
+			genopts.Tarballs = append(genopts.Tarballs, artifact.Source)
+		case "file":
+			genopts.Files = append(genopts.Files, artifact.Source)
+		case "archive":
+			genopts.Archives = append(genopts.Archives, artifact.Source)
+		}
+	}
+
+	return nil
+}
+
+func (builder *defaultDocBuilderImpl) ValidateOptions(genopts *DocGenerateOptions) error {
+	if err := genopts.Validate(); err != nil {
+		return fmt.Errorf("checking build options: %w", err)
+	}
+	return nil
+}
+
+// WriteDoc renders the document to a file
+func (builder *defaultDocBuilderImpl) WriteDoc(doc *Document, path string) error {
+	markup, err := doc.Render()
+	if err != nil {
+		return fmt.Errorf("generating document markup: %w", err)
+	}
+	logrus.Infof("writing document to %s", path)
+
+	if err := os.WriteFile(path, []byte(markup), os.FileMode(0o644)); err != nil {
+		return fmt.Errorf(
+			"writing document markup to file: %w",
+			err,
+		)
+	}
+	return nil
+}

--- a/pkg/spdx/document.go
+++ b/pkg/spdx/document.go
@@ -72,6 +72,8 @@ ExternalDocumentRef:{{ extDocFormat $value }}
 {{ end -}}
 {{- end -}}
 {{ end -}}
+{{ if .LicenseListVersion }}LicenseListVersion: {{ .LicenseListVersion }}
+{{ end -}}
 {{ if .Created }}Created: {{ dateFormat .Created }}
 {{ end }}
 

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -605,6 +605,7 @@ func (di *spdxDefaultImplementation) LicenseReader(spdxOpts *Options) (*license.
 	opts := license.DefaultReaderOptions
 	opts.CacheDir = spdxOpts.LicenseCacheDir
 	opts.LicenseDir = spdxOpts.LicenseData
+	opts.LicenseListVersion = spdxOpts.LicenseListVersion
 	// Create the new reader
 	reader, err := license.NewReaderWithOptions(opts)
 	if err != nil {

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -89,16 +89,17 @@ func (spdx *SPDX) SetImplementation(impl spdxImplementation) {
 }
 
 type Options struct {
-	AnalyzeLayers    bool
-	NoGitignore      bool     // Do not read exclusions from gitignore file
-	ProcessGoModules bool     // If true, spdx will check if dirs are go modules and analize the packages
-	OnlyDirectDeps   bool     // Only include direct dependencies from go.mod
-	ScanLicenses     bool     // Scan licenses from everypossible place unless false
-	AddTarFiles      bool     // Scan and add files inside of tarfiles
-	ScanImages       bool     // When true, scan container images for OS information
-	LicenseCacheDir  string   // Directory to cache SPDX license downloads
-	LicenseData      string   // Directory to store the SPDX licenses
-	IgnorePatterns   []string // Patterns to ignore when scanning file
+	AnalyzeLayers      bool
+	NoGitignore        bool     // Do not read exclusions from gitignore file
+	ProcessGoModules   bool     // If true, spdx will check if dirs are go modules and analize the packages
+	OnlyDirectDeps     bool     // Only include direct dependencies from go.mod
+	ScanLicenses       bool     // Scan licenses from everypossible place unless false
+	AddTarFiles        bool     // Scan and add files inside of tarfiles
+	ScanImages         bool     // When true, scan container images for OS information
+	LicenseCacheDir    string   // Directory to cache SPDX license downloads
+	LicenseData        string   // Directory to store the SPDX licenses
+	LicenseListVersion string   // Version of the SPDX license list to use
+	IgnorePatterns     []string // Patterns to ignore when scanning file
 }
 
 func (spdx *SPDX) Options() *Options {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

In order to make the license list embeddable (see https://github.com/kubernetes-sigs/bom/pull/195), we need to tell the license downloader and catalog which version to use. This PR adds a new flag to `bom generate` to add a new flag `--license-list-version` to configure which version to use.

Right now, the value is hard coded to the latest right no (3.20). Going forward what we want is to embed the data in bom and only download if we need another one.

In order to keep it current, we plan add a new presubmit to ensure at PR time that we are always embedding the latest one from the SPDX license repo.

#### Which issue(s) this PR fixes:

Related to #195

#### Special notes for your reviewer:


/cc @sbs2001 

#### Does this PR introduce a user-facing change?

```release-note
- bom will now correctly register in the SBOM the license list it used to scan code to detect licenses
- the version of the SPDX license list to use is now configurable at SBOM generation time using `--license-list-version` 
```
