### PR TITLE
Upgrade to go1.20

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
         with:

--- a/.github/workflows/verify-spdx.yaml
+++ b/.github/workflows/verify-spdx.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v3.3.0
         with:
-          go-version: 1.19
+          go-version: '1.20'
           check-latest: true
 
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,13 +1,13 @@
 defaultBaseImage: cgr.dev/chainguard/go:latest
 
 builds:
-- id: bom
-  dir: .
-  main: ./cmd/bom
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -trimpath
-  ldflags:
-  - -extldflags "-static"
-  - "{{ .Env.BOM_LDFLAGS }}"
+  - id: bom
+    dir: .
+    main: ./cmd/bom
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -extldflags "-static"
+      - "{{ .Env.BOM_LDFLAGS }}"

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: cgr.dev/chainguard/go:latest
+defaultBaseImage: docker.io/golang:1.20
 
 builds:
   - id: bom

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,37 +6,37 @@ steps:
   - name: gcr.io/cloud-builders/git
     dir: "go/src/sigs.k8s.io"
     args:
-    - "clone"
-    - "https://github.com/kubernetes-sigs/bom"
+      - "clone"
+      - "https://github.com/kubernetes-sigs/bom"
 
   - name: gcr.io/cloud-builders/git
     entrypoint: "bash"
     dir: "go/src/sigs.k8s.io/bom"
     args:
-    - '-c'
-    - |
-      git fetch
-      echo "Checking out ${_PULL_BASE_REF}"
-      git checkout ${_PULL_BASE_REF}
+      - '-c'
+      - |
+        git fetch
+        echo "Checking out ${_PULL_BASE_REF}"
+        git checkout ${_PULL_BASE_REF}
 
-  - name: 'gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye'
+  - name: 'gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye'
     dir: "go/src/sigs.k8s.io/bom"
     entrypoint: go
     env:
-    - DOCKER_CLI_EXPERIMENTAL=enabled
-    - TAG=$_GIT_TAG
-    - PULL_BASE_REF=$_PULL_BASE_REF
-    - KO_DOCKER_REPO=gcr.io/k8s-staging-bom/bom
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - TAG=$_GIT_TAG
+      - PULL_BASE_REF=$_PULL_BASE_REF
+      - KO_DOCKER_REPO=gcr.io/k8s-staging-bom/bom
     args:
-    - run
-    - mage.go
-    - buildStaging
+      - run
+      - mage.go
+      - buildStaging
 
 artifacts:
   objects:
     location: 'gs://k8s-staging-bom/${_PULL_BASE_REF}'
     paths:
-    - "go/src/sigs.k8s.io/bom/output/*"
+      - "go/src/sigs.k8s.io/bom/output/*"
 
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/bom
 
-go 1.19
+go 1.20
 
 require (
 	github.com/carolynvs/magex v0.9.0

--- a/magefile.go
+++ b/magefile.go
@@ -90,7 +90,7 @@ func Verify() error {
 	}
 
 	fmt.Println("Running golangci-lint...")
-	if err := mage.RunGolangCILint("v1.50.1", false); err != nil {
+	if err := mage.RunGolangCILint("v1.51.2", false); err != nil {
 		return err
 	}
 
@@ -248,7 +248,7 @@ func getBuildDateTime() string {
 func EnsureKO(version string) error {
 	versionToInstall := version
 	if versionToInstall == "" {
-		versionToInstall = "0.12.0"
+		versionToInstall = "0.13.0"
 	}
 
 	fmt.Printf("Checking if `ko` version %s is installed\n", versionToInstall)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature


#### What this PR does / why we need it:

- Upgrade to go1.20
- format indentation 
- using golang image becasue that have all platforms the one before just have two for now when have more we move back
- update golangci and ko

- [x] update prow jobs - https://github.com/kubernetes/test-infra/pull/29066

/hold
/assign @puerco @saschagrunert @xmudrii 

#### Which issue(s) this PR fixes:


None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Upgrade to go1.20
```
