### PR TITLE
update release binary name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,6 +46,7 @@ builds:
 
 archives:
   - format: binary
+    name_template: bom-{{ .Arch }}-{{ .Os }}
     allow_different_binary_count: true
 
 signs:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- update release binary name

on v0.5.0 release the binary name is like `bom-amd64-darwin_0.5.0_darwin_amd64` which is not good changing to `bom-arm-linux`

rehearsal https://github.com/cpanato/bom/releases/tag/v99.99.02 

/assign @puerco @saschagrunert @ameukam 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:


None
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
