### PR TITLE
Keep reading SBOM until encoding is found

### DIFF
--- a/pkg/spdx/document_unit_test.go
+++ b/pkg/spdx/document_unit_test.go
@@ -284,8 +284,8 @@ func TestValidateFiles(t *testing.T) {
 func TestGetPackagesByPurl(t *testing.T) {
 	// Open the Nginx SBOM to test queries
 	doc, err := OpenDoc("testdata/nginx.spdx")
-	require.NotNil(t, doc)
 	require.NoError(t, err)
+	require.NotNil(t, doc)
 
 	for _, tc := range []struct {
 		len  int

--- a/pkg/spdx/parser.go
+++ b/pkg/spdx/parser.go
@@ -318,7 +318,7 @@ func parseJSON(file *os.File) (doc *Document, err error) {
 			source = allFiles[elementID]
 		}
 		if source == nil {
-			logrus.Warnf("unable to find SPDX source element %s", elementID)
+			logrus.Warnf("Unable to find SPDX source element %s", elementID)
 			continue
 		}
 
@@ -406,8 +406,7 @@ func parseJSON(file *os.File) (doc *Document, err error) {
 		}
 		doc.ExternalDocRefs = append(doc.ExternalDocRefs, extRef)
 	}
-	fmt.Printf("%+v\n", doc)
-	fmt.Printf("PACKAGE:  %+v\n", doc.Packages["SPDXRef-Package-sha256-a78c2d6208eff9b672de43f880093100050983047b7b0afe0217d3656e1b0d5f"])
+
 	return doc, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:

This PR modifies the encoding detection function to read
the as much of the SBOM as required to detect the encoding.

Some tools (notably [Microsoft's `sbom-tool`](https://github.com/microsoft/sbom-tool)) put the document
creation data at the end of the document and we could not detect it by reading just a few bytes from the top. 

I pushed another commit removing some debugging output I accidentally checked in.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?


```release-note
- bom will now read the SBOM until it detects the SBOM encoding data, enabling it to parse SBOMs with the document data defined at the end of the file.
- When trying to ingest a CycloneDX document, bom will now print a more useful warning 
```
