### PR TITLE
Outliner: Autodetect open STDIN

### DIFF
--- a/cmd/bom/cmd/document.go
+++ b/cmd/bom/cmd/document.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -112,9 +111,8 @@ set the --spdx-ids to only output the IDs of the entities.
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				cmd.Help() //nolint:errcheck
-				return errors.New("you should only specify one file")
+			if len(args) == 0 {
+				args = append(args, "")
 			}
 			doc, err := spdx.OpenDoc(args[0])
 			if err != nil {

--- a/pkg/spdx/parser.go
+++ b/pkg/spdx/parser.go
@@ -49,7 +49,16 @@ func OpenDoc(path string) (doc *Document, err error) {
 	// support reading SBOMs from STDIN
 	var file *os.File
 	var isTemp bool
-	if path == "-" {
+	if path == "-" || path == "" {
+		if path == "" {
+			fi, err := os.Stdin.Stat()
+			if err != nil {
+				return nil, fmt.Errorf("checking stdin for data: %w", err)
+			}
+			if (fi.Mode() & os.ModeCharDevice) != 0 {
+				return nil, fmt.Errorf("document path not specified")
+			}
+		}
 		isTemp = true
 		file, err = bufferSTDIN()
 		if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

`bom` will now autodetect when STDIN is open to outline an SBOM.

This avoids typing a dash at the end of the cli invocation and you can just pipe it directly:

     `cat sbom | bom document outline`

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`bom` will now autodetect when STDIN is open to outline an SBOM to avoid specifying it with a dash
```
