### PR TITLE
Add Supplier Support in JSON encoded SBOMs

### DIFF
--- a/pkg/osinfo/container_scanner_test.go
+++ b/pkg/osinfo/container_scanner_test.go
@@ -64,6 +64,23 @@ func TestReadDebianPackages(t *testing.T) {
 	}
 }
 
+func TestParseDpkDb(t *testing.T) {
+	ct := ContainerScanner{}
+	_, packages, err := ct.ReadOSPackages([]string{
+		"testdata/link-with-no-dots.tar.gz", // The first layer contains the OS Info
+		"testdata/dpkg-layer1.tar.gz",       // The second layer contains the dpkg database
+	})
+
+	require.NoError(t, err)
+
+	require.Equal(t, "bash", (*packages)[4].Package)
+	require.Equal(t, "amd64", (*packages)[4].Architecture)
+	require.Equal(t, "5.0-4", (*packages)[4].Version)
+	require.Equal(t, "http://tiswww.case.edu/php/chet/bash/bashtop.html", (*packages)[4].HomePage)
+	require.Equal(t, "Matthias Klose", (*packages)[4].MaintainerName)
+	require.Equal(t, "doko@debian.org", (*packages)[4].MaintainerEmail)
+}
+
 func TestReadOSPackages(t *testing.T) {
 	ct := ContainerScanner{}
 	layer, packages, err := ct.ReadOSPackages([]string{

--- a/pkg/serialize/serialize.go
+++ b/pkg/serialize/serialize.go
@@ -163,6 +163,14 @@ func (json *JSON) buildJSONPackage(p *spdx.Package) (jsonPackage spdxJSON.Packag
 		ExternalRefs:         externalRefs,
 	}
 
+	if p.Supplier.Organization != "" {
+		jsonPackage.Supplier = fmt.Sprintf("Organization: %s", p.Supplier.Organization)
+	}
+
+	if p.Supplier.Person != "" {
+		jsonPackage.Supplier = fmt.Sprintf("Person: %s", p.Supplier.Person)
+	}
+
 	if p.VerificationCode != "" {
 		jsonPackage.VerificationCode = &spdxJSON.PackageVerificationCode{
 			Value: p.VerificationCode,

--- a/pkg/spdx/json/v2.2/types.go
+++ b/pkg/spdx/json/v2.2/types.go
@@ -97,6 +97,7 @@ type Package struct {
 	Description          string                   `json:"description,omitempty"`
 	DownloadLocation     string                   `json:"downloadLocation"`
 	Originator           string                   `json:"originator,omitempty"`
+	Supplier             string                   `json:"supplier,omitempty"`
 	SourceInfo           string                   `json:"sourceInfo,omitempty"`
 	CopyrightText        string                   `json:"copyrightText"`
 	HasFiles             []string                 `json:"hasFiles,omitempty"`
@@ -115,6 +116,8 @@ func (p *Package) GetFilesAnalyzed() bool      { return p.FilesAnalyzed }
 func (p *Package) GetLicenseDeclared() string  { return p.LicenseDeclared }
 func (p *Package) GetVersion() string          { return p.Version }
 func (p *Package) GetPrimaryPurpose() string   { return "" }
+func (p *Package) GetSupplier() string         { return p.Supplier }
+func (p *Package) GetOriginator() string       { return p.Originator }
 
 func (p *Package) GetVerificationCode() document.PackageVerificationCode {
 	if p.VerificationCode == nil {

--- a/pkg/spdx/json/v2.3/types.go
+++ b/pkg/spdx/json/v2.3/types.go
@@ -97,6 +97,7 @@ type Package struct {
 	Description          string                   `json:"description,omitempty"`
 	DownloadLocation     string                   `json:"downloadLocation"`
 	Originator           string                   `json:"originator,omitempty"`
+	Supplier             string                   `json:"supplier,omitempty"`
 	SourceInfo           string                   `json:"sourceInfo,omitempty"`
 	CopyrightText        string                   `json:"copyrightText"`
 	PrimaryPurpose       string                   `json:"primaryPackagePurpose,omitempty"`
@@ -116,6 +117,8 @@ func (p *Package) GetFilesAnalyzed() bool      { return p.FilesAnalyzed }
 func (p *Package) GetLicenseDeclared() string  { return p.LicenseDeclared }
 func (p *Package) GetVersion() string          { return p.Version }
 func (p *Package) GetPrimaryPurpose() string   { return p.PrimaryPurpose }
+func (p *Package) GetSupplier() string         { return p.Supplier }
+func (p *Package) GetOriginator() string       { return p.Originator }
 
 func (p *Package) GetVerificationCode() document.PackageVerificationCode {
 	if p.VerificationCode == nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR modifies the json serializer to add the supplier and originator data. It seems that we forgot to add it to the type and SBOMs encoded in JSON were missing the supplier info. It's there now:

```json
    {
      "SPDXID": "SPDXRef-Package-SPDXRef-Package-index.docker.io-library-debian-f5802c738e07905ae30f1006c922c1cce3a4955574751a44d5344e9cefabca8c-sha256-015f7b32198b1c57333fa9e151a0b54ccfe05dfef57e98b87c27d426f134db80-66d94da4-a71b-40b7-adc6-6d927d0f47e1",
      "name": "libp11-kit0",
      "versionInfo": "0.24.1-2",
      "filesAnalyzed": false,
      "supplier": "Person: Debian GnuTLS Maintainers (pkg-gnutls-maint@lists.alioth.debian.org)",
      "copyrightText": "NOASSERTION",
      "checksums": [],
      "externalRefs": [
        {
          "referenceCategory": "PACKAGE-MANAGER",
          "referenceLocator": "pkg:deb/debian/libp11-kit0@0.24.1-2?arch=arm64",
          "referenceType": "purl"
        }
      ]
    }
```

None

#### Special notes for your reviewer:

This PR also adds a unit test to ensure we are parsing the data in the debian db as expected.

/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
JSON-encoded files now include supplier and originator data.
```
