### PR TITLE
OSInfo: Add support for download location

### DIFF
--- a/pkg/osinfo/container_scanner.go
+++ b/pkg/osinfo/container_scanner.go
@@ -185,6 +185,33 @@ func (e *PackageDBEntry) PackageURL() string {
 	).ToString()
 }
 
+// DownloadLocation synthesizes a download location for the
+// packages based on known location for the different distros
+func (e *PackageDBEntry) DownloadLocation() string {
+	if e.Package == "" || e.Version == "" || e.Architecture == "" {
+		return ""
+	}
+
+	if e.Namespace == OSDebian {
+		dirName := e.Package[0:1]
+		if strings.HasPrefix(e.Package, "lib") {
+			dirName = e.Package[0:4]
+		}
+		return fmt.Sprintf(
+			"http://ftp.debian.org/debian/pool/main/%s/%s/%s_%s_%s.deb",
+			dirName, e.Package, e.Package, e.Version, e.Architecture,
+		)
+	} else if e.Namespace == OSWolfi {
+		return fmt.Sprintf(
+			"https://packages.wolfi.dev/os/%s/%s-%s.apk",
+			e.Architecture, e.Package, e.Version,
+		)
+	}
+
+	// TODO: For other distros we need to have the distro version
+	return ""
+}
+
 // parseDpkgDB reads a dpks database and populates a slice of PackageDBEntry
 // with information from the packages found
 func (ct *ContainerScanner) parseDpkgDB(dbPath string) (*[]PackageDBEntry, error) {

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -935,6 +935,11 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 						Locator:  (*osPackageData)[i].PackageURL(),
 					})
 				}
+
+				if (*osPackageData)[i].DownloadLocation() != "" {
+					ospk.DownloadLocation = (*osPackageData)[i].DownloadLocation()
+				}
+
 				ospk.BuildID(pkg.ID)
 				if err := pkg.AddPackage(ospk); err != nil {
 					return nil, fmt.Errorf("adding OS package to container layer: %w", err)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:

This PR adds a new `DownloadLocation()`` function to the `osinfo.PackageDBEntry` type which can generate a download location for system packages which can be used in the SBOM. It will now be used there when it is not an empty string.


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
OS Packages now can include an auto-generated download location. Initially supports Debian and Wolfi. 
```
