### PR TITLE
JSON Parser: Support top-level elements defined with relationships

### DIFF
--- a/cmd/bom/cmd/document_query_printers.go
+++ b/cmd/bom/cmd/document_query_printers.go
@@ -152,8 +152,10 @@ func getObjectField(opts queryOptions, o spdx.Object, field string) (string, err
 	case "license":
 		switch c := o.(type) {
 		case *spdx.Package:
-			if c.LicenseDeclared != "" {
+			if c.LicenseDeclared != "" && c.LicenseDeclared != spdx.NOASSERTION {
 				return c.LicenseDeclared, nil
+			} else if c.LicenseConcluded == spdx.NOASSERTION {
+				return "", nil
 			}
 			return c.LicenseConcluded, nil
 		case *spdx.File:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

SPDX supports defining the top-level elements of the SBOM using the `documentDescribes` field but also by linking elements to the document with a `DESCRIBES` relationship. This commit adds support to the JSON parser to detect top-level elements specified using the former method.

I'm also sneaking in a small change to improve printing the licenses in query results. `bom` will now detect better when licenses are `NOASSERTION` when choosing which licenses to print.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/assign @cpanato @saschagrunert @xmudrii 
/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- The `bom` json parser now supports top-level elements specified with a `DESCRIBES` relationship to the document. `documentDescribes` is, of course, still suppoirted
- License printing in query results has better `NOASSERTION` detection when choosing which license to print.
```
