### PR TITLE
use the default golangci-lint from release-utils

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - durationcheck

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	golang.org/x/term v0.10.0
 	golang.org/x/tools v0.10.0
 	gopkg.in/yaml.v2 v2.4.0
-	sigs.k8s.io/release-utils v0.7.4
+	sigs.k8s.io/release-utils v0.7.5-0.20230707140704-1bf6b4c5d954
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -184,5 +184,5 @@ gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 h1:HNSDgDCrr/6Ly3WEGKZftiE7IY19Vz2GdbOCyI4qqhc=
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-sigs.k8s.io/release-utils v0.7.4 h1:17LmJrydpUloTCtaoWj95uKlcrUp4h2A9Sa+ZL+lV9w=
-sigs.k8s.io/release-utils v0.7.4/go.mod h1:JEt2QPHItd5Pg2UKLAU8PEaSlF4bUjCZimpxFDgymVU=
+sigs.k8s.io/release-utils v0.7.5-0.20230707140704-1bf6b4c5d954 h1:6UHf2P+yurMG0iMLk1XA7pFHI+7Fg02UxMGs8VmUKuM=
+sigs.k8s.io/release-utils v0.7.5-0.20230707140704-1bf6b4c5d954/go.mod h1:T5b2rUC28a7miTkatQ3jogupUQqb+CGn1HBfoW83p40=

--- a/magefile.go
+++ b/magefile.go
@@ -95,7 +95,7 @@ func Verify() error {
 	}
 
 	fmt.Println("Running golangci-lint...")
-	if err := mage.RunGolangCILint("v1.52.2", false); err != nil {
+	if err := mage.RunGolangCILint("", false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- use the default golangci-lint from release-utils
/assign @saschagrunert @puerco @Verolop 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
