### PR TITLE
Refactor osinfo Container Scanner

### DIFF
--- a/pkg/osinfo/container_scanner_test.go
+++ b/pkg/osinfo/container_scanner_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestReadDebianPackages(t *testing.T) {
-	ct := ContainerScanner{}
+	ct := newDebianScanner()
 	for _, tc := range []struct {
 		layers      []string
 		targetLayer int
@@ -46,7 +46,7 @@ func TestReadDebianPackages(t *testing.T) {
 		// One layer, no packages, unsupported OS
 		{[]string{"testdata/link-with-no-dots.tar.gz"}, 0, 0, false, true},
 	} {
-		layerNum, packages, err := ct.ReadDebianPackages(tc.layers)
+		layerNum, packages, err := ct.ReadOSPackages(tc.layers)
 		require.Equal(t, tc.targetLayer, layerNum)
 		if !tc.shouldErr {
 			require.NoError(t, err)
@@ -65,8 +65,7 @@ func TestReadDebianPackages(t *testing.T) {
 }
 
 func TestParseDpkDb(t *testing.T) {
-	ct := ContainerScanner{}
-	_, packages, err := ct.ReadOSPackages([]string{
+	_, packages, err := ReadOSPackages([]string{
 		"testdata/link-with-no-dots.tar.gz", // The first layer contains the OS Info
 		"testdata/dpkg-layer1.tar.gz",       // The second layer contains the dpkg database
 	})
@@ -82,8 +81,7 @@ func TestParseDpkDb(t *testing.T) {
 }
 
 func TestReadOSPackages(t *testing.T) {
-	ct := ContainerScanner{}
-	layer, packages, err := ct.ReadOSPackages([]string{
+	layer, packages, err := ReadOSPackages([]string{
 		"testdata/link-with-no-dots.tar.gz", // The first layer contains the OS Info
 		"testdata/dpkg-layer1.tar.gz",       // The second layer contains the dpkg database
 	})
@@ -92,11 +90,11 @@ func TestReadOSPackages(t *testing.T) {
 	require.Len(t, *packages, 83)
 
 	// No layers should yield no error
-	_, _, err = ct.ReadOSPackages([]string{})
+	_, _, err = ReadOSPackages([]string{})
 	require.NoError(t, err)
 
 	// While an invalid file shour err
-	_, _, err = ct.ReadOSPackages([]string{"testdata/nonexistent"})
+	_, _, err = ReadOSPackages([]string{"testdata/nonexistent"})
 	require.Error(t, err)
 }
 
@@ -162,10 +160,10 @@ func TestPackageURL(t *testing.T) {
 }
 
 func TestParseApkDB(t *testing.T) {
-	ct := &ContainerScanner{}
+	ct := newAlpineScanner()
 
 	// Test we have the expected packages
-	pk, err := ct.parseApkDB("testdata/apkdb")
+	pk, err := ct.ParseDB("testdata/apkdb")
 	require.NoError(t, err)
 	require.NotNil(t, pk)
 	require.Len(t, *pk, 39)

--- a/pkg/osinfo/layer_scanner_test.go
+++ b/pkg/osinfo/layer_scanner_test.go
@@ -25,13 +25,13 @@ import (
 )
 
 func TestExtractFileFromTar(t *testing.T) {
-	loss := &LayerScanner{}
+	loss := &layerOSScanner{}
 
 	file, err := os.CreateTemp("", "extract-")
 	require.NoError(t, err)
 	defer os.Remove(file.Name())
 
-	require.NoError(t, loss.extractFileFromTar(
+	require.NoError(t, loss.ExtractFileFromTar(
 		"testdata/link-with-dots.tar.gz",
 		"./etc/os-release",
 		file.Name(),
@@ -45,7 +45,7 @@ func TestExtractFileFromTar(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(file2.Name())
 
-	require.NoError(t, loss.extractFileFromTar(
+	require.NoError(t, loss.ExtractFileFromTar(
 		"testdata/link-with-no-dots.tar.gz",
 		"etc/os-release",
 		file2.Name(),
@@ -57,7 +57,7 @@ func TestExtractFileFromTar(t *testing.T) {
 }
 
 func TestOSReleaseData(t *testing.T) {
-	loss := &LayerScanner{}
+	loss := &layerOSScanner{}
 	data, err := loss.OSReleaseData("testdata/link-with-dots.tar.gz")
 	require.NoError(t, err)
 	require.NotEmpty(t, data)

--- a/pkg/osinfo/scanner_alpine.go
+++ b/pkg/osinfo/scanner_alpine.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osinfo
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	apk "gitlab.alpinelinux.org/alpine/go/repository"
+)
+
+const apkDBPath = "lib/apk/db/installed"
+
+type alpineScanner struct {
+	ls layerScanner
+}
+
+func newAlpineScanner() containerOSScanner {
+	return &alpineScanner{ls: newLayerScanner()}
+}
+
+func (ct *alpineScanner) OSType() OSType {
+	return OSAlpine
+}
+
+// ReadApkPackages reads the last known changed copy of the apk database
+func (ct *alpineScanner) ReadOSPackages(layers []string) (layer int, pk *[]PackageDBEntry, err error) {
+	apkDatabase := ""
+
+	for i, lp := range layers {
+		tmpDB, err := os.CreateTemp("", "apkdb-")
+		if err != nil {
+			return 0, pk, fmt.Errorf("opening temporary apkdb file: %w", err)
+		}
+		tmpDBPath := tmpDB.Name()
+		if err := ct.ls.ExtractFileFromTar(lp, apkDBPath, tmpDBPath); err != nil {
+			os.Remove(tmpDBPath)
+			if _, ok := err.(ErrFileNotFoundInTar); ok {
+				continue
+			}
+			return 0, pk, fmt.Errorf("extracting apk database: %w", err)
+		}
+		logrus.Debugf("Layer %d has a newer version of apk database", i)
+		apkDatabase = tmpDBPath
+		layer = i
+	}
+
+	if apkDatabase == "" {
+		logrus.Info("apk database data is empty")
+		return layer, nil, nil
+	}
+	defer os.Remove(apkDatabase)
+
+	pk, err = ct.ParseDB(apkDatabase)
+	if err != nil {
+		return layer, nil, fmt.Errorf("parsing apk database: %w", err)
+	}
+	return layer, pk, err
+}
+
+func (ct *alpineScanner) ParseDB(dbPath string) (*[]PackageDBEntry, error) {
+	f, err := os.Open(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening apkdb: %w", err)
+	}
+	apks, err := apk.ParsePackageIndex(f)
+	if err != nil {
+		return nil, fmt.Errorf("parsing apk db: %w", err)
+	}
+
+	packages := []PackageDBEntry{}
+	for _, p := range apks {
+		cs := map[string]string{}
+		if strings.HasPrefix(p.ChecksumString(), "Q1") {
+			cs["SHA1"] = fmt.Sprintf("%x", p.Checksum)
+		} else if p.ChecksumString() != "" {
+			cs["MD5"] = fmt.Sprintf("%x", p.Checksum)
+		}
+
+		packages = append(packages, PackageDBEntry{
+			Package:        p.Name,
+			Version:        p.Version,
+			Architecture:   p.Arch,
+			Type:           "apk",
+			MaintainerName: p.Maintainer,
+			License:        p.License,
+			Checksums:      cs,
+		})
+	}
+	return &packages, nil
+}

--- a/pkg/osinfo/scanner_debian.go
+++ b/pkg/osinfo/scanner_debian.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osinfo
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	purl "github.com/package-url/packageurl-go"
+	"github.com/sirupsen/logrus"
+)
+
+type debianScanner struct {
+	ls layerScanner
+}
+
+func newDebianScanner() containerOSScanner {
+	return &debianScanner{ls: newLayerScanner()}
+}
+
+func (ct *debianScanner) OSType() OSType {
+	return OSDebian
+}
+
+// ReadDebianPackages scans through a set of container layers looking for the
+// last update to the debian package database. If found, extracts it and
+// sends it to parseDpkgDB to extract the package information from the file.
+func (ct *debianScanner) ReadOSPackages(layers []string) (layer int, pk *[]PackageDBEntry, err error) {
+	// Cycle the layers in order, trying to extract the dpkg database
+	dpkgDatabase := ""
+
+	for i, lp := range layers {
+		dpkgDB, err := os.CreateTemp("", "dpkg-")
+		if err != nil {
+			return 0, pk, fmt.Errorf("opening temp dpkg file: %w", err)
+		}
+		dpkgPath := dpkgDB.Name()
+		if err := ct.ls.ExtractFileFromTar(lp, "var/lib/dpkg/status", dpkgPath); err != nil {
+			os.Remove(dpkgDB.Name())
+			if _, ok := err.(ErrFileNotFoundInTar); ok {
+				continue
+			}
+			return 0, pk, fmt.Errorf("extracting dpkg database: %w", err)
+		}
+		logrus.Infof("Layer %d has a newer version of dpkg database", i)
+		dpkgDatabase = dpkgPath
+		layer = i
+	}
+
+	if dpkgDatabase == "" {
+		logrus.Info("dbdata is blank")
+		return layer, nil, nil
+	}
+	defer os.Remove(dpkgDatabase)
+	pk, err = ct.ParseDB(dpkgDatabase)
+	return layer, pk, err
+}
+
+// parseDpkgDB reads a dpks database and populates a slice of PackageDBEntry
+// with information from the packages found
+func (ct *debianScanner) ParseDB(dbPath string) (*[]PackageDBEntry, error) {
+	file, err := os.Open(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening for reading: %w", err)
+	}
+	defer file.Close()
+	logrus.Infof("Scanning data from dpkg database in %s", dbPath)
+	db := []PackageDBEntry{}
+	scanner := bufio.NewScanner(file)
+	var curPkg *PackageDBEntry
+	for scanner.Scan() {
+		parts := strings.SplitN(scanner.Text(), ":", 2)
+		if len(parts) < 2 {
+			continue
+		}
+
+		switch parts[0] {
+		case "Package":
+			if curPkg != nil {
+				db = append(db, *curPkg)
+			}
+			curPkg = &PackageDBEntry{
+				Package: strings.TrimSpace(parts[1]),
+				Type:    purl.TypeDebian,
+			}
+		case "Architecture":
+			if curPkg != nil {
+				curPkg.Architecture = strings.TrimSpace(parts[1])
+			}
+		case "Version":
+			if curPkg != nil {
+				curPkg.Version = strings.TrimSpace(parts[1])
+			}
+		case "Homepage":
+			if curPkg != nil {
+				curPkg.HomePage = strings.TrimSpace(parts[1])
+			}
+		case "Maintainer":
+			if curPkg != nil {
+				mparts := strings.SplitN(parts[1], "<", 2)
+				if len(mparts) == 2 {
+					curPkg.MaintainerName = strings.TrimSpace(mparts[0])
+					curPkg.MaintainerEmail = strings.TrimSuffix(strings.TrimSpace(mparts[1]), ">")
+				}
+			}
+		}
+	}
+
+	logrus.Infof("Found %d packages", len(db))
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanning database file: %w", err)
+	}
+
+	return &db, err
+}

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -879,7 +879,6 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 	logrus.Infof("Image manifest lists %d layers", len(manifest.LayerFiles))
 
 	// Scan the container layers for OS information:
-	ct := osinfo.ContainerScanner{}
 	var osPackageData *[]osinfo.PackageDBEntry
 	var layerNum int
 	layerPaths := []string{}
@@ -889,7 +888,7 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 
 	// Scan for package data if option is set
 	if spdxOpts.ScanImages {
-		layerNum, osPackageData, err = ct.ReadOSPackages(layerPaths)
+		layerNum, osPackageData, err = osinfo.ReadOSPackages(layerPaths)
 		if err != nil {
 			return nil, fmt.Errorf("getting os data from container: %w", err)
 		}


### PR DESCRIPTION
This change starts to move individual OS type logic out to individual implementations and files.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This change will make it easier to write and test new OS types for `bom generate --scan-images`

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I tried to keep the `osinfo` package API as close to the same as possible. I made the `containerScanner` and `layerScanner` interfaces and their implementations internal to the package as they're not currently used externally. 

#### Does this PR introduce a user-facing change?


```release-note
NONE
```
