### PR TITLE
fix(osinfo): Fix package URL type for OS packages

### DIFF
--- a/pkg/license/licensefakes/fake_downloader_implementation.go
+++ b/pkg/license/licensefakes/fake_downloader_implementation.go
@@ -39,9 +39,8 @@ type FakeDownloaderImplementation struct {
 	}
 	GetLatestTagStub        func() (string, error)
 	getLatestTagMutex       sync.RWMutex
-	getLatestTagArgsForCall []struct {
-	}
-	getLatestTagReturns struct {
+	getLatestTagArgsForCall []struct{}
+	getLatestTagReturns     struct {
 		result1 string
 		result2 error
 	}
@@ -69,9 +68,8 @@ type FakeDownloaderImplementation struct {
 	}
 	VersionStub        func() string
 	versionMutex       sync.RWMutex
-	versionArgsForCall []struct {
-	}
-	versionReturns struct {
+	versionArgsForCall []struct{}
+	versionReturns     struct {
 		result1 string
 	}
 	versionReturnsOnCall map[int]struct {
@@ -148,8 +146,7 @@ func (fake *FakeDownloaderImplementation) DownloadLicenseArchiveReturnsOnCall(i 
 func (fake *FakeDownloaderImplementation) GetLatestTag() (string, error) {
 	fake.getLatestTagMutex.Lock()
 	ret, specificReturn := fake.getLatestTagReturnsOnCall[len(fake.getLatestTagArgsForCall)]
-	fake.getLatestTagArgsForCall = append(fake.getLatestTagArgsForCall, struct {
-	}{})
+	fake.getLatestTagArgsForCall = append(fake.getLatestTagArgsForCall, struct{}{})
 	stub := fake.GetLatestTagStub
 	fakeReturns := fake.getLatestTagReturns
 	fake.recordInvocation("GetLatestTag", []interface{}{})
@@ -300,8 +297,7 @@ func (fake *FakeDownloaderImplementation) SetOptionsArgsForCall(i int) *license.
 func (fake *FakeDownloaderImplementation) Version() string {
 	fake.versionMutex.Lock()
 	ret, specificReturn := fake.versionReturnsOnCall[len(fake.versionArgsForCall)]
-	fake.versionArgsForCall = append(fake.versionArgsForCall, struct {
-	}{})
+	fake.versionArgsForCall = append(fake.versionArgsForCall, struct{}{})
 	stub := fake.VersionStub
 	fakeReturns := fake.versionReturns
 	fake.recordInvocation("Version", []interface{}{})

--- a/pkg/osinfo/container_scanner.go
+++ b/pkg/osinfo/container_scanner.go
@@ -27,6 +27,7 @@ type containerOSScanner interface {
 	ReadOSPackages(layers []string) (layer int, pk *[]PackageDBEntry, err error)
 	ParseDB(path string) (pk *[]PackageDBEntry, err error)
 	OSType() OSType
+	PURLType() string
 }
 
 // ReadOSPackages reads a bunch of layers and extracts the os package
@@ -59,8 +60,7 @@ func ReadOSPackages(layers []string) (
 		return 0, nil, nil
 	}
 	layerNum, packages, err = cs.ReadOSPackages(layers)
-	purlType := string(cs.OSType())
-	setPurlData(purlType, string(osKind), packages)
+	setPurlData(cs.PURLType(), string(osKind), packages)
 	return layerNum, packages, err
 }
 

--- a/pkg/osinfo/scanner_alpine.go
+++ b/pkg/osinfo/scanner_alpine.go
@@ -35,6 +35,10 @@ func newAlpineScanner() containerOSScanner {
 	return &alpineScanner{ls: newLayerScanner()}
 }
 
+func (ct *alpineScanner) PURLType() string {
+	return "apk"
+}
+
 func (ct *alpineScanner) OSType() OSType {
 	return OSAlpine
 }

--- a/pkg/osinfo/scanner_debian.go
+++ b/pkg/osinfo/scanner_debian.go
@@ -34,6 +34,10 @@ func newDebianScanner() containerOSScanner {
 	return &debianScanner{ls: newLayerScanner()}
 }
 
+func (ct *debianScanner) PURLType() string {
+	return "deb"
+}
+
 func (ct *debianScanner) OSType() OSType {
 	return OSDebian
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The tool was outputting invalid purl types. I looked at using [github.com/package-url/packageurl-go](https://github.com/package-url/packageurl-go), but it is missing types (like `apk`, opend package-url/packageurl-go#63) defined in [the spec](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst).

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
