### PR TITLE
Trigger docs workflow on changes to workflow config file

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths:
       - "docs/**"
+      - ".github/workflows/docs.yml"
     branches:
       - main  # Set a branch to deploy
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

The docs GitHub workflow has been failing for some time with a git error. This updates the workflow file so:

- We can get new logs showing what this git failure is; and
- We get the docs job to run if there are configuration changes to the workflow itself

Assuming this shows what the previous failures are from, there may be additional updates needed to correct that root cause. A temporary debugging step has been included to help understand what is happening and will be removed as a follow up.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
