### PR TITLE
Fix goreleaser --skip-sign deprecation

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -136,7 +136,7 @@ func BuildBinariesSnapshot() error {
 	os.Setenv("BOM_LDFLAGS", ldFlag)
 
 	return sh.RunV("goreleaser", "release", "--clean",
-		"--snapshot", "--skip-sign")
+		"--snapshot", "--skip=sign")
 }
 
 func BuildBinaries() error {


### PR DESCRIPTION
See https://goreleaser.com/deprecations/#-skip

Per output of `go run mage.go buildBinariesSnapshot`

#### What type of PR is this?
/kind bug
/kind  cleanup

#### What this PR does / why we need it:

Fixes deprecation warning in `magefile`

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

```release-note
NONE
```
