### PR TITLE
Fix mage verify

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -85,7 +85,7 @@ func Verify() error {
 	}
 
 	fmt.Println("Running external dependency checks...")
-	if err := mage.VerifyDeps("v0.3.0", "", "", true); err != nil {
+	if err := mage.VerifyDeps("", "", "", true); err != nil {
 		return err
 	}
 
@@ -95,7 +95,7 @@ func Verify() error {
 	}
 
 	fmt.Println("Running golangci-lint...")
-	if err := mage.RunGolangCILint("", false); err != nil {
+	if err := mage.RunGolangCILint("", true); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Updates zeitgeist to v0.4.3 to fix version check

Tested via go run mage.go

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

Fixes local (non-ci) builds using default mage target

#### Which issue(s) this PR fixes:

None

See: kubernetes-sigs/zeitgeist#739 and kubernetes-sigs/release-utils#96


#### Special notes for your reviewer:

If you have an existing version of zeitgeist before 0.4.3 you will have to do `rm $GOPATH/bin/zeitgeist` before `go run mage.go` 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
