### PR TITLE
Updates for dependabot and release job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,22 +2,32 @@ version: 2
 
 updates:
 
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: "daily"
-  labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
-  open-pull-requests-limit: 10
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+    open-pull-requests-limit: 10
+    groups:
+      all:
+        update-types:
+          - "minor"
+          - "patch"
 
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily"
-  labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
-  open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+    open-pull-requests-limit: 10
+    groups:
+      all:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         run: echo "tag_name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
 
       - name: Install tejolote
-        uses: puerco/release-actions/setup-tejolote@6c88cda6495b4415966e61f20798fb96a9081397 # main
+        uses: kubernetes-sigs/release-actions/setup-tejolote@10fecc1c66829d291b2f2fb1a27329d152f212e6 # v0.1.3
 
       - run: |
           tejolote attest --artifacts github://kubernetes-sigs/bom/${{ steps.tag.outputs.tag_name }} github://kubernetes-sigs/bom/"${GITHUB_RUN_ID}" --output bom.intoto.json --sign


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- group dependabot updates 
- update setup-tejolote to use new home

/assign @Verolop @puerco @xmcqueen @ameukam 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- group dependabot updates 
- update setup-tejolote to use new home
```
