### PR TITLE
Bump builder image to go1.22-bookworm

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -19,7 +19,7 @@ steps:
         echo "Checking out ${_PULL_BASE_REF}"
         git checkout ${_PULL_BASE_REF}
 
-  - name: 'gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm'
+  - name: 'gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm'
     dir: "go/src/sigs.k8s.io/bom"
     entrypoint: go
     env:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR bumps the builder image to go 1.22 

#### Which issue(s) this PR fixes:

This should fix [image builds](https://github.com/stacklok/minder/actions/runs/8517196913/job/23327380715?pr=2892).

#### Special notes for your reviewer:

/cc @cpanato @saschagrunert @xmudrii 

#### Does this PR introduce a user-facing change?

```release-note
Builder image updated to `latest-go1.22-bookworm`
```
