### PR TITLE
FIX: creating_bill_of_materials.md

### DIFF
--- a/docs/content/en/Tutorials/creating_bill_of_materials.md
+++ b/docs/content/en/Tutorials/creating_bill_of_materials.md
@@ -99,7 +99,7 @@ data, and other attributes.
 [Packages](https://spdx.github.io/spdx-spec/3-package-information/) are a
 non-specific element in SPDX representing anything that can group other elements.
 An `.rpm` or `.deb` package can be an SPDX package, but so can be a container
-image or a tarball. Packages contain files, but can also contain other files
+image or a tarball. Packages contain files, but can also contain other packages
 or a mix of both. An image, for example, can be viewed as a package, which
 contains other packages (its layers), and those, in turn, a set of files.
 


### PR DESCRIPTION
There is a small error in the Files and Packages section. A package may contain other packages, files, or a mix

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

There was a simple mistake in phrasing which didn't specifiy that packages may contain other packages. This clarifies that.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
