### PR TITLE
Use the correct form of `sha256.Sum256`.

### DIFF
--- a/pkg/license/download.go
+++ b/pkg/license/download.go
@@ -295,7 +295,7 @@ func (ddi *DefaultDownloaderImpl) GetLicenses(tag string) (licenses *List, err e
 // cacheFileName return the cache filename for an URL.
 func (ddi *DefaultDownloaderImpl) cacheFileName(url string) string {
 	return filepath.Join(
-		ddi.Options.CacheDir, fmt.Sprintf("%x.json", sha256.New().Sum([]byte(url))),
+		ddi.Options.CacheDir, fmt.Sprintf("%x.json", sha256.Sum256([]byte(url))),
 	)
 }
 


### PR DESCRIPTION
`sha256.New().Sum(foo)` appends the SHA-256 hash for nil to foo. See https://go.dev/play/p/vSW0U3Hq4qk

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Honestly, you probably don't _need_ it but the current behavior of defining a cache filename as `$URL + SHA256("")` is silly. This would be an actual bug if y'all weren't using `MkdirAll` to build out the path, but you are.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

That's a good shirt.

#### Does this PR introduce a user-facing change?

```release-note
Cache filenames generated by the license downloader will now be derived from a SHA256 digest of the URL, rather than the URL itself + SHA256("")
```
