### PR TITLE
Zeb/find

### DIFF
--- a/cmd/bom/cmd/document_outline.go
+++ b/cmd/bom/cmd/document_outline.go
@@ -54,6 +54,9 @@ set the --spdx-ids to only output the IDs of the entities.
 			if err != nil {
 				return fmt.Errorf("opening doc: %w", err)
 			}
+			if outlineOpts.Find != "" {
+				doc.FilterReverseDependencies(outlineOpts.Find, outlineOpts.Recursion)
+			}
 			output, err := doc.Outline(outlineOpts)
 			if err != nil {
 				return fmt.Errorf("generating document outline: %w", err)
@@ -88,6 +91,13 @@ set the --spdx-ids to only output the IDs of the entities.
 		"purl",
 		false,
 		"show package urls instead of name@version",
+	)
+	outlineCmd.PersistentFlags().StringVarP(
+		&outlineOpts.Find,
+		"find",
+		"f",
+		"",
+		"Find node in DAG",
 	)
 
 	parent.AddCommand(outlineCmd)

--- a/pkg/spdx/document.go
+++ b/pkg/spdx/document.go
@@ -131,6 +131,7 @@ type DrawingOptions struct {
 	ASCIIOnly   bool
 	Purls       bool
 	Version     bool
+	Find        string
 }
 
 // String returns the SPDX string of the external document ref.
@@ -311,6 +312,19 @@ func treeLines(o *DrawingOptions, depth int, connector string) string {
 	res := " " + strings.Repeat(fmt.Sprintf(" %s ", stick), depth)
 	res += " " + connector + " "
 	return res
+}
+
+// FilterReverseDependencies filters the document to only include direct paths to
+// Objects with the name name. Hence finding that Object's reverse dependencies.
+func (d *Document) FilterReverseDependencies(name string, depth int) {
+	keepPackages := map[string]*Package{}
+	for packageName, p := range d.Packages {
+		if !recursiveNameFilter(name, p, depth, &map[string]bool{}) {
+			continue
+		}
+		keepPackages[packageName] = p
+	}
+	d.Packages = keepPackages
 }
 
 // Outline draws an outline of the relationships inside the doc.

--- a/pkg/spdx/object.go
+++ b/pkg/spdx/object.go
@@ -46,9 +46,11 @@ type Object interface {
 	SetEntity(*Entity)
 	AddRelationship(*Relationship)
 	GetRelationships() *[]*Relationship
+	FilterRelationships(filter func(r *Relationship) bool)
 	ToProvenanceSubject() *intoto.Subject
 	getProvenanceSubjects(opts *ProvenanceOptions, seen *map[string]struct{}) []intoto.Subject
 	GetElementByID(string) Object
+	GetName() string
 }
 
 type Entity struct {
@@ -77,6 +79,11 @@ func (e *Entity) Options() *ObjectOptions {
 // SPDXID returns the SPDX reference string for the object.
 func (e *Entity) SPDXID() string {
 	return e.ID
+}
+
+// GetName returns the Objects name as a string.
+func (e *Entity) GetName() string {
+	return e.Name
 }
 
 // SPDXID returns the SPDX reference string for the object.
@@ -153,6 +160,21 @@ func (e *Entity) Render() (string, error) {
 
 func (e *Entity) GetRelationships() *[]*Relationship {
 	return &e.Relationships
+}
+
+// FilterRelationships filters relationships according to a filter function.
+// On a true the relationship is kept, on a false the relationship is dropped.
+func (e *Entity) FilterRelationships(filter func(r *Relationship) bool) {
+	keepRelationships := []*Relationship{}
+	for _, rel := range e.Relationships {
+		if filter(rel) {
+			keepRelationships = append(keepRelationships, rel)
+		}
+	}
+	if len(keepRelationships) == 0 {
+		keepRelationships = nil
+	}
+	e.Relationships = keepRelationships
 }
 
 // ToProvenanceSubject converts the element to an intoto subject, suitable

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -401,7 +401,11 @@ func (p *Package) Draw(builder *strings.Builder, o *DrawingOptions, depth int, s
 		connector = connectorL
 	}
 
-	fmt.Fprintf(builder, treeLines(o, depth, connector)+"🔗 %d Relationships\n", len(p.Relationships))
+	// not printed when find is set since relationships will be filtered out from the graph.
+	if o.Find == "" {
+		fmt.Fprintf(builder, treeLines(o, depth, connector)+"🔗 %d Relationships\n", len(p.Relationships))
+	}
+
 	if depth >= o.Recursion && o.Recursion > 0 {
 		fmt.Fprintln(builder, treeLines(o, depth-1, ""))
 		return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds the `-f` or `-find` command line argument to the `document outline` command. This feature filters the output of `outline` to only show the queried nodes and the nodes directly on the path there from root.  For example if the output of `document outline file.spdx` looked like this: 
```
  │                                                                                                                                                                                           
  │ 📦 DESCRIBES 1 Packages                                                                                                                                                                   
  │                                                                                                                                                                                           
  ├ nginx                                                                                                                                                                                     
  │  │ 🔗 2 Relationships                                                                                                                                                                     
  │  ├ CONTAINS PACKAGE nginx (amd64/linux)                                                                                                                                                   
  │  │  │ 🔗 4 Relationships                                                                                                                                                                  
  │  │  ├ CONTAINS PACKAGE a.tar.gz                                                                                         
  │  │  ├ CONTAINS PACKAGE b.tar.gz                                                                                                                                                                                                      
  │  │  ├ CONTAINS PACKAGE c.tar.gz                                                                                        
  │  │  ├ CONTAINS PACKAGE d.tar.gz                                                                                                                                                                                
  │  │  └ VARIANT_OF PACKAGE nginx                                                                                                                                                            
  │  │                                                                                                                                                                                        
  │  ├ CONTAINS PACKAGE nginx (arm/linux)                                                                                                                                                     
  │  │  │ 🔗 2 Relationships                                                                                                                                                                  
  │  │  ├ CONTAINS PACKAGE d.tar.gz                                                                                                                                                                                   
  │  │  └ VARIANT_OF PACKAGE nginx             
```
The output of `document outline -f d.tar.gz`  would look like this:
```
  │                                                                                                                                                                                           
  │ 📦 DESCRIBES 1 Packages                                                                                                                                                                   
  │                                                                                                                                                                                           
  ├ nginx                                                                                                                                                                                                                                                                                                                                               
  │  ├ CONTAINS PACKAGE nginx (amd64/linux)                                                                                                                                                                                                                                                                                                                                                                                                   
  │  │  └ CONTAINS PACKAGE d.tar.gz                                                                                                                                                                                                                                                                                                                                        
  │  │                                                                                                                                                                                        
  │  ├ CONTAINS PACKAGE nginx (arm/linux)                                                                                                                                                                                                                                                                                                                   
  │  │  └ CONTAINS PACKAGE d.tar.gz                                                                                                                                                                                          
```

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `-f/--find` command line argument to the `document outline` command. This filters the output to only show queried nodes and nodes and nodes directly on the path there from the root node.
```

