### PR TITLE
Add `bom document todot`

### DIFF
--- a/cmd/bom/cmd/document.go
+++ b/cmd/bom/cmd/document.go
@@ -31,5 +31,6 @@ func AddDocument(parent *cobra.Command) {
 
 	AddOutline(documentCmd)
 	AddQuery(documentCmd)
+	AddToDot(documentCmd)
 	parent.AddCommand(documentCmd)
 }

--- a/cmd/bom/cmd/document_todot.go
+++ b/cmd/bom/cmd/document_todot.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/bom/pkg/spdx"
+)
+
+func AddToDot(parent *cobra.Command) {
+	toDotOpts := &spdx.ToDotOptions{}
+	toDotCmd := &cobra.Command{
+		PersistentPreRunE: initLogging,
+		Short:             "bom document todot -> dump the SPDX document as dotlang.",
+		Long: `bom document todot -> dump the SPDX document as dotlang.
+
+This Subcommand translates the graph like structure of an spdx document into dotlang,
+An abstract grammar used to represent graphs https://graphviz.org/doc/info/lang.html.
+
+This is printed to stdout but can easily be piped to a file like so.
+
+bom document todot file.spdx > file.dot
+
+The output can also be filtered by depth, (--depth), inverse dependencies (--find)
+or subgraph (--subgraph) to aid with visualisation by tools like Graphviz
+
+bom will try to add useful information to dotlangs tooltip node attribute.
+`,
+		Use:           "todot SPDX_FILE|URL",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				args = append(args, "")
+			}
+			doc, err := spdx.OpenDoc(args[0])
+			if err != nil {
+				return fmt.Errorf("opening doc: %w", err)
+			}
+			if toDotOpts.Find != "" {
+				doc.FilterReverseDependencies(toDotOpts.Find, toDotOpts.Depth)
+			}
+			fmt.Println(doc.ToDot(toDotOpts))
+			return nil
+		},
+	}
+	toDotCmd.PersistentFlags().StringVarP(
+		&toDotOpts.Find,
+		"find",
+		"f",
+		"",
+		"Find node in DAG",
+	)
+	toDotCmd.PersistentFlags().IntVarP(
+		&toDotOpts.Depth,
+		"depth",
+		"d",
+		-1,
+		"Depth to traverse",
+	)
+	toDotCmd.PersistentFlags().StringVarP(
+		&toDotOpts.SubGraphRoot,
+		"subgraph",
+		"s",
+		"",
+		"SPDXID of the root node for the subgraph",
+	)
+	parent.AddCommand(toDotCmd)
+}

--- a/pkg/spdx/document.go
+++ b/pkg/spdx/document.go
@@ -295,6 +295,7 @@ func (d *Document) ToDot(o *ToDotOptions) string {
 	}
 	seenFilter := &map[string]struct{}{}
 	var ok bool
+	found := false
 	for _, p := range d.Packages {
 		if o.SubGraphRoot != "" {
 			p, ok = recursiveIDSearch(o.SubGraphRoot, p, &map[string]struct{}{}).(*Package)
@@ -304,10 +305,15 @@ func (d *Document) ToDot(o *ToDotOptions) string {
 			if !ok {
 				log.Fatal("Interface object is not of expected type Package")
 			}
+			found = true
 		} else {
+			found = true
 			out += escape(d.Name) + " -> " + escape(p.SPDXID()) + ";\n"
 		}
 		out += toDot(p, o.Depth, seenFilter)
+	}
+	if !found {
+		log.Fatalf("Unable to generate a dot file for the '%s' subgraph", o.SubGraphRoot)
 	}
 	return fmt.Sprintf("digraph {\n%s\n}\n", out)
 }

--- a/pkg/spdx/document.go
+++ b/pkg/spdx/document.go
@@ -120,6 +120,12 @@ type ExternalRef struct {
 	Locator  string // unique string with no spaces
 }
 
+type ToDotOptions struct {
+	Find         string
+	Depth        int
+	SubGraphRoot string
+}
+
 type DrawingOptions struct {
 	Width       int
 	Height      int
@@ -280,6 +286,30 @@ func (d *Document) Render() (doc string, err error) {
 	doc += docSb266.String()
 
 	return doc, err
+}
+
+func (d *Document) ToDot(o *ToDotOptions) string {
+	out := ""
+	if o.SubGraphRoot == "" {
+		out = escape(d.Name) + ";\n"
+	}
+	seenFilter := &map[string]struct{}{}
+	var ok bool
+	for _, p := range d.Packages {
+		if o.SubGraphRoot != "" {
+			p, ok = recursiveIDSearch(o.SubGraphRoot, p, &map[string]struct{}{}).(*Package)
+			if p == nil {
+				continue
+			}
+			if !ok {
+				log.Fatal("Interface object is not of expected type Package")
+			}
+		} else {
+			out += escape(d.Name) + " -> " + escape(p.SPDXID()) + ";\n"
+		}
+		out += toDot(p, o.Depth, seenFilter)
+	}
+	return fmt.Sprintf("digraph {\n%s\n}\n", out)
 }
 
 // AddFile adds a file contained in the package.

--- a/pkg/spdx/document.go
+++ b/pkg/spdx/document.go
@@ -293,6 +293,10 @@ func (d *Document) ToDot(o *ToDotOptions) string {
 	if o.SubGraphRoot == "" {
 		out = escape(d.Name) + ";\n"
 	}
+	if len(d.Packages) == 0 {
+		log.Fatal("No graphs to generate")
+	}
+
 	seenFilter := &map[string]struct{}{}
 	var ok bool
 	found := false

--- a/pkg/spdx/file.go
+++ b/pkg/spdx/file.go
@@ -61,6 +61,10 @@ type File struct {
 	LicenseInfoInFile string // GPL-3.0-or-later
 }
 
+func (f *File) ToDot() string {
+	return fmt.Sprintf("%q", f.SPDXID())
+}
+
 func NewFile() (f *File) {
 	f = &File{}
 	f.Opts = &ObjectOptions{}

--- a/pkg/spdx/json/document/document.go
+++ b/pkg/spdx/json/document/document.go
@@ -64,6 +64,8 @@ type Package interface {
 	GetCopyrightText() string
 	GetLicenseConcluded() string
 	GetFilesAnalyzed() bool
+	GetVendorInfo() string
+	GetSourceInfo() string
 	GetLicenseDeclared() string
 	GetVersion() string
 	GetVerificationCode() PackageVerificationCode

--- a/pkg/spdx/json/v2.2/types.go
+++ b/pkg/spdx/json/v2.2/types.go
@@ -99,6 +99,7 @@ type Package struct {
 	Originator           string                   `json:"originator,omitempty"`
 	Supplier             string                   `json:"supplier,omitempty"`
 	SourceInfo           string                   `json:"sourceInfo,omitempty"`
+	VendorInfo           string                   `json:"vendorInfo,omitempty"`
 	CopyrightText        string                   `json:"copyrightText"`
 	HasFiles             []string                 `json:"hasFiles,omitempty"`
 	LicenseInfoFromFiles []string                 `json:"licenseInfoFromFiles,omitempty"`
@@ -117,6 +118,8 @@ func (p *Package) GetLicenseDeclared() string  { return p.LicenseDeclared }
 func (p *Package) GetVersion() string          { return p.Version }
 func (p *Package) GetPrimaryPurpose() string   { return "" }
 func (p *Package) GetSupplier() string         { return p.Supplier }
+func (p *Package) GetVendorInfo() string       { return p.VendorInfo }
+func (p *Package) GetSourceInfo() string       { return p.SourceInfo }
 func (p *Package) GetOriginator() string       { return p.Originator }
 
 func (p *Package) GetVerificationCode() document.PackageVerificationCode {

--- a/pkg/spdx/json/v2.3/types.go
+++ b/pkg/spdx/json/v2.3/types.go
@@ -99,6 +99,7 @@ type Package struct {
 	Originator           string                   `json:"originator,omitempty"`
 	Supplier             string                   `json:"supplier,omitempty"`
 	SourceInfo           string                   `json:"sourceInfo,omitempty"`
+	VendorInfo           string                   `json:"vendorInfo,omitempty"`
 	CopyrightText        string                   `json:"copyrightText"`
 	PrimaryPurpose       string                   `json:"primaryPackagePurpose,omitempty"`
 	HasFiles             []string                 `json:"hasFiles,omitempty"`
@@ -118,6 +119,8 @@ func (p *Package) GetLicenseDeclared() string  { return p.LicenseDeclared }
 func (p *Package) GetVersion() string          { return p.Version }
 func (p *Package) GetPrimaryPurpose() string   { return p.PrimaryPurpose }
 func (p *Package) GetSupplier() string         { return p.Supplier }
+func (p *Package) GetVendorInfo() string       { return p.VendorInfo }
+func (p *Package) GetSourceInfo() string       { return p.SourceInfo }
 func (p *Package) GetOriginator() string       { return p.Originator }
 
 func (p *Package) GetVerificationCode() document.PackageVerificationCode {

--- a/pkg/spdx/object.go
+++ b/pkg/spdx/object.go
@@ -51,6 +51,7 @@ type Object interface {
 	getProvenanceSubjects(opts *ProvenanceOptions, seen *map[string]struct{}) []*intoto.ResourceDescriptor
 	GetElementByID(string) Object
 	GetName() string
+	ToDot() string
 }
 
 type Entity struct {

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -98,6 +98,8 @@ type Package struct {
 	Comment              string   // a place for the SPDX document creator to record any general comments
 	HomePage             string   // A web site that serves as the package home page
 	PrimaryPurpose       string   // Estimate of the most likely package usage
+	VendorInfo           string
+	SourceInfo           string
 
 	// Supplier: the actual distribution source for the package/directory
 	Supplier struct {
@@ -134,6 +136,29 @@ func NewPackage() (p *Package) {
 	p = &Package{}
 	p.Opts = &ObjectOptions{}
 	return p
+}
+
+// ToDot returns a representation of the package as a dotlang node.
+func (p *Package) ToDot() string {
+	packageData := structToString(p, true, "RWMutex", "Opts", "Relationships")
+
+	sURL := ""
+	if url := p.Purl(); url != nil {
+		sURL = fmt.Sprintf(`URL: %s\n`, url.ToString())
+	}
+
+	name := p.Name
+	if p.Version != "" {
+		name = name + "@" + p.Version
+	}
+
+	return fmt.Sprintf(
+		`%q [label=%q tooltip="%s%s" fontname="monospace"]`,
+		p.SPDXID(),
+		name,
+		packageData,
+		sURL,
+	)
 }
 
 // AddFile adds a file contained in the package.

--- a/pkg/spdx/parser.go
+++ b/pkg/spdx/parser.go
@@ -251,6 +251,8 @@ func parseJSON(file *os.File) (doc *Document, err error) {
 			LicenseInfoFromFiles: []string{},
 			LicenseDeclared:      pData.GetLicenseDeclared(),
 			Version:              pData.GetVersion(),
+			VendorInfo:           pData.GetVendorInfo(),
+			SourceInfo:           pData.GetSourceInfo(),
 			VerificationCode:     pData.GetVerificationCode().GetValue(),
 			// Comment:              pData.Comment,
 			// HomePage:             pData.HomePage,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Adds the `todot` sub command for `bom document`. This command dumps the contents of the provided spdx file as a string of [dotlang](https://graphviz.org/doc/info/lang.html) to stdout. This output can then be piped into a file for visualization by [graphvis](https://graphviz.org/) or other related programs. This overcomes the visualization limitations of `bom document outline` detailed here #530. 

`todot` comes with a few cli arguments to help filter large SBOMs into a more digestible graph. 
- `--find` finds the reverse dependencies of a given package 
- `--subgraph` promotes a node with the given SPDXID to root ignoring all nodes that aren't descendants of the given node. 
- `--depth` the recursive depth. 

for example the sbom. 
```
SPDXVersion: SPDX-2.2
SPDXID: Document
DocumentName: Document


##### Package: glib

PackageName: glib
SPDXID: package-glib


##### Package: gnome

PackageName: gnome
SPDXID: package-gnome

##### Package: python

PackageName: python
SPDXID: package-python

##### Package: sqlite

PackageName: sqlite
SPDXID: package-sqlite

Relationship: package-glib CONTAINS package-python
Relationship: package-gnome CONTAINS package-python
Relationship: package-python CONTAINS package-sqlite
```
Will produce the dot 
`bom document todot file.spdx > file.dot`
```dot
digraph {
"Document";
"Document" -> "package-gnome";
"package-gnome" [label="gnome" tooltip="SPXID: package-gnome\nversion: \nlicense: \nSupplier-Org:\nSupplier-Person: \nOriginator-Org: \nOriginator-Person: \nURL: " fontname = "monospace"];
"package-gnome" -> "package-python";
"package-python" [label="python" tooltip="SPXID: package-python\nversion: \nlicense: \nSupplier-Org:\nSupplier-Person: \nOriginator-Org: \nOriginator-Person: \nURL: " fontname = "monospace"];
"package-python" -> "package-sqlite";
"package-sqlite" [label="sqlite" tooltip="SPXID: package-sqlite\nversion: \nlicense: \nSupplier-Org:\nSupplier-Person: \nOriginator-Org: \nOriginator-Person: \nURL: " fontname = "monospace"];
"Document" -> "package-glib";
"package-glib" [label="glib" tooltip="SPXID: package-glib\nversion: \nlicense: \nSupplier-Org:\nSupplier-Person: \nOriginator-Org: \nOriginator-Person: \nURL: " fontname = "monospace"];
"package-glib" -> "package-python";
}
```

which when rendered with graphviz produces the following `.png`
`dot -Tpng file.dot > file.png`

<img width="222" height="347" alt="file" src="https://github.com/user-attachments/assets/c68d9fce-0a23-497d-8bbf-0c3e702e0b0a" />
 
#### Which issue(s) this PR fixes:
Fixes #530
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #530

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
Added `-f/--find` command line argument to the `document outline` command. This filters the output to only show queried nodes and nodes and nodes directly on the path there from the root node.
-->

```release-note
added the `todot` subcommand to `document`. This dumps a representation of the spdx graph to stdout as dotlang. 
```

