### PR TITLE
update cloudbuild job to use go1.24 and fix deprecated field

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 timeout: 3600s
 options:
-  substitution_option: ALLOW_LOOSE
+  substitutionOption: ALLOW_LOOSE
 steps:
   - name: gcr.io/cloud-builders/git
     dir: "go/src/sigs.k8s.io"
@@ -19,7 +19,7 @@ steps:
         echo "Checking out ${_PULL_BASE_REF}"
         git checkout ${_PULL_BASE_REF}
 
-  - name: 'gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm'
+  - name: 'gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm'
     dir: "go/src/sigs.k8s.io/bom"
     entrypoint: go
     env:


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- update cloudbuild job to use go1.24 and fix deprecated field

/assign @puerco @saschagrunert @xmudrii 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
update cloudbuild job to use go1.24 and fix deprecated field
```
