### PR TITLE
top level relationship fix

### DIFF
--- a/pkg/spdx/parser.go
+++ b/pkg/spdx/parser.go
@@ -750,13 +750,16 @@ func parseTagValue(file *os.File) (doc *Document, err error) {
 			if p, ok := objects[rdata.Peer].(*Package); ok {
 				logrus.Debugf("doc %s describes package %s", doc.ID, rdata.Peer)
 				doc.Packages[rdata.Peer] = p
+				continue
 			}
 
 			if f, ok := objects[rdata.Peer].(*File); ok {
 				logrus.Debugf("doc %s describes file %s", doc.ID, rdata.Peer)
 				doc.Files[(objects[rdata.Peer]).(*File).SPDXID()] = f //nolint: errcheck
+				continue
 			}
-			continue
+
+			return nil, fmt.Errorf("unable to find peer object with SPDXID %s", rdata.Peer)
 		}
 
 		// Check if the source object is defined


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes a bug where the parser would return an empty `Document` instead of an error if the peer  in the top level relationship was not present in the document. 

e.g 
`bom document outline example.spdx` now outputs 
```
FATA opening doc: unable to find peer object with SPDXID doesnt-exist 
```
instead of 
```
               _      
 ___ _ __   __| |_  __
/ __| '_ \ / _` \ \/ /
\__ \ |_) | (_| |>  < 
|___/ .__/ \__,_/_/\_\
    |_|               

 📂 SPDX Document SBOM-SPDX-c6d8b3cc-b41b-4ce9-9e5f-ce24616b7fbe
  │ 
  │ 📦 DESCRIBES 0 Packages
  │ 
  └ 📄 DESCRIBES 0 Files



```
for the document.
```
SPDXID: SPDXRef-DOCUMENT

##### Package: nginx

PackageName: nginx
SPDXID: SPDXRef-nginx

##### Package: python 

PackageName: python
SPDXID: SPDXRef-python

Relationship: SPDXRef-nginx CONTAINS SPDXRef-Python
Relationship: SPDXRef-DOCUMENT DESCRIBES doesnt-exist
```
Note: to repeat this the document needs at least 2 layers of relationships otherwise the elements are added to the document as leaf nodes.  

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fatal error now encountered when attempting to parse a document with a malformed top level relationship. 
```
