### PR TITLE
fix release binary name

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,5 @@
 name: github pages
-permissions:
-  contents: write
+
 on:
   push:
     paths:
@@ -9,9 +8,15 @@ on:
     branches:
       - main  # Set a branch to deploy
 
+permissions: {}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - 'v*'
 
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -22,8 +24,9 @@ jobs:
 
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
+          cache: false
 
       - name: Install cosign
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -32,5 +32,5 @@ jobs:
 
       - name: check binary
         run: |
-          ./dist/bom-amd64-linux version
+          ./dist/bom_linux_amd64_v1/bom version
           cat ./dist/bom.json.spdx

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -5,10 +5,17 @@ on:
     branches:
       - 'main'
   pull_request:
+    branches:
+      - 'main'
+
+permissions: {}
 
 jobs:
   snapshot:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
       - name: Check out code onto GOPATH
@@ -16,8 +23,9 @@ jobs:
 
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
+          cache: false
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0

--- a/.github/workflows/verify-spdx.yaml
+++ b/.github/workflows/verify-spdx.yaml
@@ -2,17 +2,25 @@ name: Validate SPDX Conformance
 
 on:
   pull_request:
-    branches: ['main']
+    branches:
+      - 'main'
+
+permissions: {}
 
 jobs:
   check-spdx:
     name: Check SPDX SBOMs
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v3.3.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
+          cache: false
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,8 +16,6 @@ gomod:
 
 builds:
   - id: bom
-    no_unique_dist_dir: true
-    binary: bom-{{ .Arch }}-{{ .Os }}
     main: ./cmd/bom
     goos:
       - darwin
@@ -48,6 +46,7 @@ builds:
 archives:
   - formats:
       - binary
+    name_template: "{{ .ProjectName }}-{{ .Arch }}-{{ .Os }}"
     allow_different_binary_count: true
 
 signs:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,7 @@ signs:
 
 sboms:
   - id: bom
-    cmd: ./bom-amd64-linux
+    cmd: ./bom_linux_amd64_v1/bom
     args:
       - generate
       - "--output"


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

our previous releases are using the binary format `bom-<arch>-<os>` but the last one `v0.7.0` the format was `bom-amd64-darwin_0.7.0_darwin_amd64`


this pr fix to use the previous format, after this will cut a new release

/assign @saschagrunert @puerco 

#### Which issue(s) this PR fixes:



None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
