### PR TITLE
add support to generate python, rust, and nodejs sboms

### DIFF
--- a/cmd/bom/cmd/generate_test.go
+++ b/cmd/bom/cmd/generate_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/bom/pkg/spdx"
+)
+
+func TestBuildSplitOutputFile(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		lang     string
+		expected string
+	}{
+		{
+			name:     "simple extension",
+			input:    "output.spdx",
+			lang:     "go",
+			expected: "output-go.spdx",
+		},
+		{
+			name:     "json format",
+			input:    "output.json",
+			lang:     "python",
+			expected: "output-python.json",
+		},
+		{
+			name:     "double extension",
+			input:    "output.spdx.json",
+			lang:     "rust",
+			expected: "output-rust.spdx.json",
+		},
+		{
+			name:     "no extension",
+			input:    "output",
+			lang:     "node",
+			expected: "output-node",
+		},
+		{
+			name:     "path with directory",
+			input:    "/tmp/sbom/output.spdx",
+			lang:     "go",
+			expected: "/tmp/sbom/output-go.spdx",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := buildSplitOutputFile(tc.input, tc.lang)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestValidateMultiLangMode(t *testing.T) {
+	// Valid modes should not error
+	opts := &generateOptions{
+		directories:   []string{"."},
+		format:        spdx.FormatTagValue,
+		multiLangMode: spdx.MultiLangMerged,
+	}
+	require.NoError(t, opts.Validate())
+
+	opts.multiLangMode = spdx.MultiLangSplit
+	require.NoError(t, opts.Validate())
+
+	// Invalid mode should error
+	opts.multiLangMode = "invalid"
+	require.Error(t, opts.Validate())
+}

--- a/mage.go
+++ b/mage.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 /*

--- a/pkg/osinfo/container_scanner.go
+++ b/pkg/osinfo/container_scanner.go
@@ -50,7 +50,7 @@ func ReadOSPackages(layers []string) (
 
 	// First, let's try to determine which OS the container is based on
 	osKind := OSType("")
-	osInfoLayerNum := 0
+	osInfoLayerPath := layers[0]
 	for i, lp := range layers {
 		exists, err := ls.FileExistsInTar(lp, OsReleasePath, AltOSReleasePath)
 		if err != nil {
@@ -58,11 +58,11 @@ func ReadOSPackages(layers []string) (
 		}
 		if exists {
 			logrus.Debugf(" > found os-release in layer %d", i)
-			osInfoLayerNum = i
+			osInfoLayerPath = lp
 		}
 	}
 
-	osKind, err = ls.OSType(layers[osInfoLayerNum])
+	osKind, err = ls.OSType(osInfoLayerPath)
 	if err != nil {
 		return 0, nil, fmt.Errorf("reading os type from layer: %w", err)
 	}

--- a/pkg/osinfo/layer_scanner.go
+++ b/pkg/osinfo/layer_scanner.go
@@ -18,6 +18,7 @@ package osinfo
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"errors"
 	"fmt"
@@ -319,10 +320,8 @@ func isStreamCompressed(r io.ReadSeeker) (bool, error) {
 
 	// Check for gzip magic bytes
 	// From: https://github.com/golang/go/blob/1fadc392ccaefd76ef7be5b685fb3889dbee27c6/src/compress/gzip/gunzip.go#L185
-	if sample[0] == 0x1f && sample[1] == 0x8b && sample[2] == 0x08 {
-		return true, nil
-	}
-	return false, nil
+	gzipMagic := []byte{0x1f, 0x8b, 0x08}
+	return bytes.Equal(sample[:], gzipMagic), nil
 }
 
 // ExtractDirectoryFromTar extracts all files from a tarball that match the

--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -128,28 +128,38 @@ func (db *DocBuilder) Generate(genopts *DocGenerateOptions) (*Document, error) {
 	return doc, nil
 }
 
+// MultiLangMode controls how multi-language SBOMs are generated.
+const (
+	MultiLangMerged = "merged" // Default: all languages in one SBOM
+	MultiLangSplit  = "split"  // Produce per-language SBOM files
+)
+
 type DocGenerateOptions struct {
-	AnalyseLayers       bool                  // A flag that controls if deep layer analysis should be performed
-	NoGitignore         bool                  // Do not read exclusions from gitignore file
-	ProcessGoModules    bool                  // Analyze go.mod to include data about packages
-	OnlyDirectDeps      bool                  // Only include direct dependencies from go.mod
-	ScanLicenses        bool                  // Try to look into files to determine their license
-	ScanImages          bool                  // When true, scan images for OS information
-	ConfigFile          string                // Path to SBOM configuration file
-	Format              string                // Output format
-	OutputFile          string                // Output location
-	Name                string                // Name to use in the resulting document
-	Namespace           string                // Namespace for the document (a unique URI)
-	CreatorPerson       string                // Document creator information
-	License             string                // Main license of the document
-	LicenseListVersion  string                // Version of the SPDX list to use
-	Tarballs            []string              // A slice of docker archives (tar)
-	Archives            []string              // A list of archive files to add as packages
-	Files               []string              // A slice of naked files to include in the bom
-	Images              []string              // A slice of docker images
-	Directories         []string              // A slice of directories to convert into packages
-	IgnorePatterns      []string              // A slice of regexp patterns to ignore when scanning dirs
-	ExternalDocumentRef []ExternalDocumentRef // List of external documents related to the bom
+	AnalyseLayers        bool                  // A flag that controls if deep layer analysis should be performed
+	NoGitignore          bool                  // Do not read exclusions from gitignore file
+	ProcessGoModules     bool                  // Analyze go.mod to include data about packages
+	ProcessPythonModules bool                  // Analyze Python manifests to include data about packages
+	ProcessNodeModules   bool                  // Analyze package.json to include data about packages
+	ProcessRustModules   bool                  // Analyze Cargo.toml to include data about packages
+	OnlyDirectDeps       bool                  // Only include direct dependencies from go.mod
+	ScanLicenses         bool                  // Try to look into files to determine their license
+	ScanImages           bool                  // When true, scan images for OS information
+	MultiLangMode        string                // How to handle multi-language projects: "merged" (default) or "split"
+	ConfigFile           string                // Path to SBOM configuration file
+	Format               string                // Output format
+	OutputFile           string                // Output location
+	Name                 string                // Name to use in the resulting document
+	Namespace            string                // Namespace for the document (a unique URI)
+	CreatorPerson        string                // Document creator information
+	License              string                // Main license of the document
+	LicenseListVersion   string                // Version of the SPDX list to use
+	Tarballs             []string              // A slice of docker archives (tar)
+	Archives             []string              // A list of archive files to add as packages
+	Files                []string              // A slice of naked files to include in the bom
+	Images               []string              // A slice of docker images
+	Directories          []string              // A slice of directories to convert into packages
+	IgnorePatterns       []string              // A slice of regexp patterns to ignore when scanning dirs
+	ExternalDocumentRef  []ExternalDocumentRef // List of external documents related to the bom
 }
 
 func (o *DocGenerateOptions) Validate() error {

--- a/pkg/spdx/builder_implementation.go
+++ b/pkg/spdx/builder_implementation.go
@@ -91,6 +91,9 @@ func (builder *defaultDocBuilderImpl) CreateSPDXClient(genopts *DocGenerateOptio
 	}
 	spdx.Options().AnalyzeLayers = genopts.AnalyseLayers
 	spdx.Options().ProcessGoModules = genopts.ProcessGoModules
+	spdx.Options().ProcessPythonModules = genopts.ProcessPythonModules
+	spdx.Options().ProcessNodeModules = genopts.ProcessNodeModules
+	spdx.Options().ProcessRustModules = genopts.ProcessRustModules
 	spdx.Options().ScanImages = genopts.ScanImages
 	spdx.Options().LicenseListVersion = genopts.LicenseListVersion
 

--- a/pkg/spdx/multilang_e2e_test.go
+++ b/pkg/spdx/multilang_e2e_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdx
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiLangMergedDetection tests that a directory containing both Python
+// and Node.js manifest files has dependencies from both languages merged into
+// a single Package when all language scanners are enabled.
+func TestMultiLangMergedDetection(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write a Python requirements.txt
+	reqContent := `requests==2.28.1
+flask==2.2.2
+`
+	err := os.WriteFile(filepath.Join(tmpDir, PythonRequirementsFile), []byte(reqContent), 0o600)
+	require.NoError(t, err)
+
+	// Write a Node package.json
+	packageJSON := `{
+  "name": "multi-lang-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "express": "4.18.2",
+    "lodash": "4.17.21"
+  }
+}`
+	err = os.WriteFile(filepath.Join(tmpDir, NodePackageFile), []byte(packageJSON), 0o600)
+	require.NoError(t, err)
+
+	// Need at least one regular file for PackageFromDirectory
+	err = os.WriteFile(filepath.Join(tmpDir, "README.md"), []byte("# Multi-lang project\n"), 0o600)
+	require.NoError(t, err)
+
+	// Use empty PATH to force fallback parsing for both languages
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", t.TempDir())
+	defer os.Setenv("PATH", origPath)
+
+	sut := NewSPDX()
+	sut.Options().ProcessGoModules = false
+	sut.Options().ProcessPythonModules = true
+	sut.Options().ProcessNodeModules = true
+	sut.Options().ProcessRustModules = false
+	sut.Options().ScanLicenses = false
+
+	pkg, err := sut.PackageFromDirectory(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, pkg)
+
+	// Collect all DEPENDS_ON peer names
+	rels := *pkg.GetRelationships()
+	depNames := map[string]bool{}
+	for _, rel := range rels {
+		if rel.Type == DEPENDS_ON && rel.Peer != nil {
+			depNames[rel.Peer.GetName()] = true
+		}
+	}
+
+	// Verify Python deps are present
+	require.True(t, depNames["requests"], "expected Python dependency 'requests'")
+	require.True(t, depNames["flask"], "expected Python dependency 'flask'")
+
+	// Verify Node deps are present
+	require.True(t, depNames["express"], "expected Node dependency 'express'")
+	require.True(t, depNames["lodash"], "expected Node dependency 'lodash'")
+
+	// Should have at least 4 DEPENDS_ON relationships
+	depCount := 0
+	for _, rel := range rels {
+		if rel.Type == DEPENDS_ON {
+			depCount++
+		}
+	}
+	require.GreaterOrEqual(t, depCount, 4, "expected at least 4 dependency relationships")
+}
+
+// TestMultiLangSelectiveDisable tests that disabling a language scanner
+// prevents its dependencies from appearing in the output even when its
+// manifest file is present.
+func TestMultiLangSelectiveDisable(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write both manifests
+	err := os.WriteFile(filepath.Join(tmpDir, PythonRequirementsFile), []byte("requests==2.28.1\n"), 0o600)
+	require.NoError(t, err)
+	packageJSON := `{"name":"test","dependencies":{"lodash":"4.17.21"}}`
+	err = os.WriteFile(filepath.Join(tmpDir, NodePackageFile), []byte(packageJSON), 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "app.py"), []byte("pass\n"), 0o600)
+	require.NoError(t, err)
+
+	// Use empty PATH
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", t.TempDir())
+	defer os.Setenv("PATH", origPath)
+
+	// Enable Python, disable Node
+	sut := NewSPDX()
+	sut.Options().ProcessGoModules = false
+	sut.Options().ProcessPythonModules = true
+	sut.Options().ProcessNodeModules = false
+	sut.Options().ProcessRustModules = false
+	sut.Options().ScanLicenses = false
+
+	pkg, err := sut.PackageFromDirectory(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, pkg)
+
+	rels := *pkg.GetRelationships()
+	depNames := map[string]bool{}
+	for _, rel := range rels {
+		if rel.Type == DEPENDS_ON && rel.Peer != nil {
+			depNames[rel.Peer.GetName()] = true
+		}
+	}
+
+	// Python dep should be present
+	require.True(t, depNames["requests"], "expected Python dependency 'requests'")
+	// Node dep should NOT be present
+	require.False(t, depNames["lodash"], "did not expect Node dependency 'lodash' when Node scanning is disabled")
+}
+
+// TestMultiLangSPDXPackageIDs verifies that packages from different languages
+// get distinct SPDX IDs (no collisions).
+func TestMultiLangSPDXPackageIDs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write both manifests
+	err := os.WriteFile(filepath.Join(tmpDir, PythonRequirementsFile), []byte("requests==2.28.1\nnumpy==1.23.5\n"), 0o600)
+	require.NoError(t, err)
+	packageJSON := `{"name":"test","dependencies":{"express":"4.18.2","lodash":"4.17.21"}}`
+	err = os.WriteFile(filepath.Join(tmpDir, NodePackageFile), []byte(packageJSON), 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "main.py"), []byte("pass\n"), 0o600)
+	require.NoError(t, err)
+
+	// Use empty PATH
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", t.TempDir())
+	defer os.Setenv("PATH", origPath)
+
+	sut := NewSPDX()
+	sut.Options().ProcessGoModules = false
+	sut.Options().ProcessPythonModules = true
+	sut.Options().ProcessNodeModules = true
+	sut.Options().ProcessRustModules = false
+	sut.Options().ScanLicenses = false
+
+	pkg, err := sut.PackageFromDirectory(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, pkg)
+
+	// Collect all dependency SPDX IDs
+	rels := *pkg.GetRelationships()
+	ids := map[string]string{} // id -> name
+	for _, rel := range rels {
+		if rel.Type == DEPENDS_ON && rel.Peer != nil {
+			id := rel.Peer.SPDXID()
+			name := rel.Peer.GetName()
+			if existing, ok := ids[id]; ok {
+				t.Fatalf("SPDX ID collision: %q used by both %q and %q", id, existing, name)
+			}
+			ids[id] = name
+		}
+	}
+
+	require.Len(t, ids, 4, "expected 4 unique dependency SPDX IDs")
+}
+
+// TestMultiLangNoManifests verifies that PackageFromDirectory still works
+// when no language manifests are present (just files).
+func TestMultiLangNoManifests(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(tmpDir, "README.md"), []byte("# Hello\n"), 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "data.txt"), []byte("some data\n"), 0o600)
+	require.NoError(t, err)
+
+	sut := NewSPDX()
+	sut.Options().ProcessGoModules = false
+	sut.Options().ProcessPythonModules = true
+	sut.Options().ProcessNodeModules = true
+	sut.Options().ProcessRustModules = true
+	sut.Options().ScanLicenses = false
+
+	pkg, err := sut.PackageFromDirectory(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, pkg)
+
+	// Should have no DEPENDS_ON relationships (only CONTAINS for the files)
+	rels := *pkg.GetRelationships()
+	for _, rel := range rels {
+		require.NotEqual(t, DEPENDS_ON, rel.Type, "should not have DEPENDS_ON when no manifests present")
+	}
+}

--- a/pkg/spdx/nodemod.go
+++ b/pkg/spdx/nodemod.go
@@ -1,0 +1,516 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdx
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	purl "github.com/package-url/packageurl-go"
+	"github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/release-utils/command"
+	"sigs.k8s.io/release-utils/helpers"
+	"sigs.k8s.io/release-utils/http"
+
+	"sigs.k8s.io/bom/pkg/license"
+)
+
+const (
+	nodeDownloadDir = spdxTempDir + "/node-scanner"
+	NodePackageFile = "package.json"
+)
+
+// NodePackage basic pkg data we need.
+type NodePackage struct {
+	TmpDir        bool
+	Name          string // e.g. "express", "@types/node"
+	Version       string // e.g. "4.18.2"
+	LocalDir      string
+	LicenseID     string
+	CopyrightText string
+}
+
+// GetName returns the package name.
+func (pkg *NodePackage) GetName() string { return pkg.Name }
+
+// ToSPDXPackage builds an SPDX package from the node package data.
+func (pkg *NodePackage) ToSPDXPackage() (*Package, error) {
+	spdxPackage := NewPackage()
+	spdxPackage.Options().Prefix = "npm"
+	spdxPackage.Name = pkg.Name
+	spdxPackage.BuildID(pkg.Name, pkg.Version)
+	spdxPackage.Version = pkg.Version
+	spdxPackage.LicenseConcluded = pkg.LicenseID
+	spdxPackage.CopyrightText = pkg.CopyrightText
+
+	// Build the download location URL.
+	// For scoped packages like @scope/name, the tarball URL is:
+	//   https://registry.npmjs.org/@scope/name/-/name-version.tgz
+	// For unscoped packages:
+	//   https://registry.npmjs.org/name/-/name-version.tgz
+	basename := pkg.Name
+	if strings.HasPrefix(pkg.Name, "@") {
+		// Scoped package: extract just the name part after the slash
+		parts := strings.SplitN(pkg.Name, "/", 2)
+		if len(parts) == 2 {
+			basename = parts[1]
+		}
+	}
+	spdxPackage.DownloadLocation = fmt.Sprintf(
+		"https://registry.npmjs.org/%s/-/%s-%s.tgz",
+		pkg.Name, basename, pkg.Version,
+	)
+
+	if packageurl := pkg.PackageURL(); packageurl != "" {
+		spdxPackage.ExternalRefs = append(spdxPackage.ExternalRefs, ExternalRef{
+			Category: CatPackageManager,
+			Type:     "purl",
+			Locator:  packageurl,
+		})
+	}
+	return spdxPackage, nil
+}
+
+// PackageURL returns a purl if the node package has enough data to generate
+// one. If data is missing, it will return an empty string.
+func (pkg *NodePackage) PackageURL() string {
+	if pkg.Name == "" || pkg.Version == "" {
+		return ""
+	}
+
+	var namespace, name string
+	if strings.HasPrefix(pkg.Name, "@") {
+		// Scoped package: @scope/name -> namespace="@scope", name="name"
+		parts := strings.SplitN(pkg.Name, "/", 2)
+		if len(parts) == 2 {
+			namespace = parts[0]
+			name = parts[1]
+		} else {
+			return ""
+		}
+	} else {
+		namespace = ""
+		name = pkg.Name
+	}
+
+	return purl.NewPackageURL(
+		purl.TypeNPM, namespace, name,
+		pkg.Version, nil, "",
+	).ToString()
+}
+
+type NodeModuleOptions struct {
+	Path         string
+	ScanLicenses bool
+}
+
+// NodeModule abstracts the node module data of a project.
+type NodeModule struct {
+	impl     NodeModImplementation
+	opts     *NodeModuleOptions
+	Packages []*NodePackage
+}
+
+// Options returns a pointer to the module options set.
+func (mod *NodeModule) Options() *NodeModuleOptions {
+	return mod.opts
+}
+
+// SetScanLicenses sets the ScanLicenses option on the module.
+func (mod *NodeModule) SetScanLicenses(v bool) {
+	mod.opts.ScanLicenses = v
+}
+
+// GetPackageConverters returns the module's packages as spdxPackageConverter interfaces.
+func (mod *NodeModule) GetPackageConverters() []spdxPackageConverter {
+	converters := make([]spdxPackageConverter, len(mod.Packages))
+	for i, pkg := range mod.Packages {
+		converters[i] = pkg
+	}
+	return converters
+}
+
+type NodeModImplementation interface {
+	BuildPackageList(path string) ([]*NodePackage, error)
+	DownloadPackage(*NodePackage, *NodeModuleOptions, bool) error
+	RemoveDownloads([]*NodePackage) error
+	LicenseReader() (*license.Reader, error)
+	ScanPackageLicense(*NodePackage, *license.Reader, *NodeModuleOptions) error
+}
+
+// NewNodeModule returns a new node module with default options.
+func NewNodeModule() *NodeModule {
+	return &NodeModule{
+		opts: &NodeModuleOptions{},
+		impl: &NodeModDefaultImpl{},
+	}
+}
+
+// NewNodeModuleFromPath returns a new node module from the specified path.
+func NewNodeModuleFromPath(path string) (*NodeModule, error) {
+	mod := NewNodeModule()
+	mod.opts.Path = path
+	return mod, nil
+}
+
+// Open initializes a node module from the specified path.
+func (mod *NodeModule) Open() error {
+	pkgs, err := mod.impl.BuildPackageList(mod.opts.Path)
+	if err != nil {
+		return fmt.Errorf("building node package list: %w", err)
+	}
+	mod.Packages = pkgs
+	return nil
+}
+
+// RemoveDownloads cleans all downloads.
+func (mod *NodeModule) RemoveDownloads() error {
+	return mod.impl.RemoveDownloads(mod.Packages)
+}
+
+// ScanLicenses scans the licenses and populates the fields.
+func (mod *NodeModule) ScanLicenses() error {
+	if mod.Packages == nil {
+		return errors.New("unable to scan license files, package list is nil")
+	}
+
+	reader, err := mod.impl.LicenseReader()
+	if err != nil {
+		return fmt.Errorf("creating license scanner: %w", err)
+	}
+
+	return scanPackageLicenses(
+		mod.Packages, "node", reader,
+		func(pkg *NodePackage) error {
+			return mod.impl.DownloadPackage(pkg, mod.opts, false)
+		},
+		func(pkg *NodePackage, r *license.Reader) error {
+			return mod.impl.ScanPackageLicense(pkg, r, mod.opts)
+		},
+	)
+}
+
+type NodeModDefaultImpl struct {
+	licenseReader *license.Reader
+}
+
+// BuildPackageList builds a list of node packages by running npm ls --all --json.
+// If npm is not available, it falls back to reading package.json directly.
+func (di *NodeModDefaultImpl) BuildPackageList(path string) ([]*NodePackage, error) {
+	npmBin, err := exec.LookPath("npm")
+	if err != nil {
+		logrus.Warn("npm not found, falling back to reading package.json directly")
+		return di.buildPackageListFromFile(path)
+	}
+
+	npmRun := command.NewWithWorkDir(path, npmBin, "ls", "--all", "--json")
+	output, err := npmRun.RunSilentSuccessOutput()
+	if err != nil {
+		logrus.Warnf("npm ls failed, falling back to package.json: %v", err)
+		return di.buildPackageListFromFile(path)
+	}
+
+	// Parse the JSON output from npm ls
+	type npmDep struct {
+		Version      string             `json:"version"`
+		Dependencies map[string]*npmDep `json:"dependencies"`
+	}
+	type npmOutput struct {
+		Dependencies map[string]*npmDep `json:"dependencies"`
+	}
+
+	var result npmOutput
+	if err := json.Unmarshal([]byte(output.Output()), &result); err != nil {
+		return nil, fmt.Errorf("parsing npm ls output: %w", err)
+	}
+
+	// Flatten the dependency tree recursively to get unique name@version pairs
+	seen := map[string]bool{}
+	var pkgs []*NodePackage
+
+	var flatten func(deps map[string]*npmDep)
+	flatten = func(deps map[string]*npmDep) {
+		for name, dep := range deps {
+			key := name + "@" + dep.Version
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			pkgs = append(pkgs, &NodePackage{
+				Name:    name,
+				Version: dep.Version,
+			})
+
+			if dep.Dependencies != nil {
+				flatten(dep.Dependencies)
+			}
+		}
+	}
+
+	if result.Dependencies != nil {
+		flatten(result.Dependencies)
+	}
+
+	logrus.Infof("Found %d node packages from dependency tree", len(pkgs))
+	return pkgs, nil
+}
+
+// buildPackageListFromFile reads package.json and extracts dependencies
+// and devDependencies keys (without version resolution).
+func (di *NodeModDefaultImpl) buildPackageListFromFile(path string) ([]*NodePackage, error) {
+	pkgFile := filepath.Join(path, NodePackageFile)
+	if !helpers.Exists(pkgFile) {
+		return nil, fmt.Errorf("package.json not found in %s", path)
+	}
+
+	data, err := os.ReadFile(pkgFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading package.json: %w", err)
+	}
+
+	type packageJSON struct {
+		Dependencies    map[string]string `json:"dependencies"`
+		DevDependencies map[string]string `json:"devDependencies"`
+	}
+
+	var pj packageJSON
+	if err := json.Unmarshal(data, &pj); err != nil {
+		return nil, fmt.Errorf("parsing package.json: %w", err)
+	}
+
+	var pkgs []*NodePackage
+	seen := map[string]bool{}
+
+	addDeps := func(deps map[string]string) {
+		for name, version := range deps {
+			// Strip version prefixes like ^, ~, >= etc. for a best-effort version
+			version = strings.TrimLeft(version, "^~>=<! ")
+			key := name + "@" + version
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			pkgs = append(pkgs, &NodePackage{
+				Name:    name,
+				Version: version,
+			})
+		}
+	}
+
+	addDeps(pj.Dependencies)
+	addDeps(pj.DevDependencies)
+
+	logrus.Infof(
+		"Parsed package.json, found %d dependencies (without full resolution)",
+		len(pkgs),
+	)
+	return pkgs, nil
+}
+
+// DownloadPackage takes a pkg, downloads it from the npm registry and sets
+// the download dir in the LocalDir field.
+func (di *NodeModDefaultImpl) DownloadPackage(pkg *NodePackage, _ *NodeModuleOptions, force bool) error {
+	if pkg.LocalDir != "" && helpers.Exists(pkg.LocalDir) && !force {
+		logrus.WithField("package", pkg.Name).Infof("Not downloading %s as it already has local data", pkg.Name)
+		return nil
+	}
+
+	logrus.WithField("package", pkg.Name).Debugf("Downloading package %s@%s", pkg.Name, pkg.Version)
+
+	// Create temp directory
+	if !helpers.Exists(filepath.Join(os.TempDir(), nodeDownloadDir)) {
+		if err := os.MkdirAll(
+			filepath.Join(os.TempDir(), nodeDownloadDir), os.FileMode(0o755),
+		); err != nil {
+			return fmt.Errorf("creating parent tmpdir: %w", err)
+		}
+	}
+
+	tmpDir, err := os.MkdirTemp(filepath.Join(os.TempDir(), nodeDownloadDir), "package-download-")
+	if err != nil {
+		return fmt.Errorf("creating temporary dir: %w", err)
+	}
+
+	// Fetch package metadata from the npm registry to get the tarball URL
+	registryURL := fmt.Sprintf("https://registry.npmjs.org/%s/%s", pkg.Name, pkg.Version)
+	agent := http.NewAgent()
+	data, err := agent.Get(registryURL)
+	if err != nil {
+		return fmt.Errorf("fetching npm registry metadata for %s@%s (%s): %w", pkg.Name, pkg.Version, registryURL, err)
+	}
+
+	// Parse the registry response to get the tarball URL
+	type registryResponse struct {
+		Dist struct {
+			Tarball string `json:"tarball"`
+		} `json:"dist"`
+	}
+
+	var regResp registryResponse
+	if err := json.Unmarshal(data, &regResp); err != nil {
+		return fmt.Errorf("parsing registry response for %s: %w", pkg.Name, err)
+	}
+
+	if regResp.Dist.Tarball == "" {
+		return fmt.Errorf("no tarball URL found for %s@%s", pkg.Name, pkg.Version)
+	}
+
+	// Download the tarball
+	tarballData, err := agent.Get(regResp.Dist.Tarball)
+	if err != nil {
+		return fmt.Errorf("downloading tarball for %s (%s): %w", pkg.Name, regResp.Dist.Tarball, err)
+	}
+
+	// Extract the tgz to the temp directory
+	if err := extractTgz(tarballData, tmpDir); err != nil {
+		return fmt.Errorf("extracting npm tarball: %w", err)
+	}
+
+	logrus.WithField("package", pkg.Name).Infof("Node package %s@%s downloaded to %s", pkg.Name, pkg.Version, tmpDir)
+	pkg.LocalDir = tmpDir
+	pkg.TmpDir = true
+	return nil
+}
+
+// extractTgz extracts a .tgz archive to the destination directory.
+// npm tarballs have a "package/" prefix in the tar entries, which is stripped.
+func extractTgz(data []byte, destDir string) error {
+	gr, err := gzip.NewReader(strings.NewReader(string(data)))
+	if err != nil {
+		return fmt.Errorf("opening gzip reader: %w", err)
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar entry: %w", err)
+		}
+
+		// npm tarballs have a "package/" prefix in entries, strip it
+		name := header.Name
+		parts := strings.SplitN(name, "/", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		destPath := filepath.Join(destDir, parts[1])
+
+		// Sanitize path to prevent zip-slip
+		if !strings.HasPrefix(filepath.Clean(destPath), filepath.Clean(destDir)+string(os.PathSeparator)) {
+			continue
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(destPath, 0o755); err != nil {
+				return fmt.Errorf("creating directory: %w", err)
+			}
+		case tar.TypeReg:
+			// Create parent directories
+			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+				return fmt.Errorf("creating parent directory: %w", err)
+			}
+
+			outFile, err := os.Create(destPath)
+			if err != nil {
+				return fmt.Errorf("creating file: %w", err)
+			}
+
+			limited := io.LimitReader(tr, maxExtractFileSize)
+			_, err = io.Copy(outFile, limited)
+			outFile.Close()
+			if err != nil {
+				return fmt.Errorf("extracting file: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// RemoveDownloads takes a list of packages and removes their downloads.
+func (di *NodeModDefaultImpl) RemoveDownloads(packageList []*NodePackage) error {
+	for _, pkg := range packageList {
+		if pkg.Name != "" && helpers.Exists(pkg.LocalDir) && pkg.TmpDir {
+			if err := os.RemoveAll(pkg.LocalDir); err != nil {
+				return fmt.Errorf("removing package data: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// LicenseReader returns a license reader.
+func (di *NodeModDefaultImpl) LicenseReader() (*license.Reader, error) {
+	if di.licenseReader == nil {
+		opts := license.DefaultReaderOptions
+		opts.CacheDir = filepath.Join(os.TempDir(), spdxLicenseDlCache)
+		opts.LicenseDir = filepath.Join(os.TempDir(), spdxLicenseData)
+		if !helpers.Exists(opts.CacheDir) {
+			if err := os.MkdirAll(opts.CacheDir, os.FileMode(0o755)); err != nil {
+				return nil, fmt.Errorf("creating dir: %w", err)
+			}
+		}
+		reader, err := license.NewReaderWithOptions(opts)
+		if err != nil {
+			return nil, fmt.Errorf("creating reader: %w", err)
+		}
+
+		di.licenseReader = reader
+	}
+	return di.licenseReader, nil
+}
+
+// ScanPackageLicense scans a package for licensing info.
+func (di *NodeModDefaultImpl) ScanPackageLicense(
+	pkg *NodePackage, reader *license.Reader, _ *NodeModuleOptions,
+) error {
+	dir := pkg.LocalDir
+	if dir == "" {
+		return fmt.Errorf("no local directory set for package %s", pkg.Name)
+	}
+
+	licenseResult, err := reader.ReadTopLicense(dir)
+	if err != nil {
+		return fmt.Errorf("scanning package %s for licensing information: %w", pkg.Name, err)
+	}
+
+	if licenseResult != nil {
+		logrus.Debugf(
+			"Package %s license is %s", pkg.Name,
+			licenseResult.License.LicenseID,
+		)
+		pkg.LicenseID = licenseResult.License.LicenseID
+		pkg.CopyrightText = licenseResult.Text
+	} else {
+		logrus.Warnf("Could not find licensing information for package %s", pkg.Name)
+	}
+	return nil
+}

--- a/pkg/spdx/nodemod_e2e_test.go
+++ b/pkg/spdx/nodemod_e2e_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdx
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNodeBuildPackageListFromFile tests the fallback path that parses
+// package.json directly without needing npm installed.
+func TestNodeBuildPackageListFromFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	packageJSON := `{
+  "name": "test-project",
+  "version": "1.0.0",
+  "dependencies": {
+    "express": "^4.18.2",
+    "lodash": "~4.17.21"
+  },
+  "devDependencies": {
+    "@types/node": ">=18.11.9",
+    "typescript": "5.0.4"
+  }
+}`
+	err := os.WriteFile(filepath.Join(tmpDir, NodePackageFile), []byte(packageJSON), 0o600)
+	require.NoError(t, err)
+
+	impl := &NodeModDefaultImpl{}
+	pkgs, err := impl.buildPackageListFromFile(tmpDir)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 4)
+
+	// Build a map for easier verification
+	pkgMap := map[string]string{}
+	for _, pkg := range pkgs {
+		pkgMap[pkg.Name] = pkg.Version
+	}
+
+	// Versions should have prefixes stripped
+	require.Equal(t, "4.18.2", pkgMap["express"])
+	require.Equal(t, "4.17.21", pkgMap["lodash"])
+	require.Equal(t, "18.11.9", pkgMap["@types/node"])
+	require.Equal(t, "5.0.4", pkgMap["typescript"])
+}
+
+// TestNodeBuildPackageListFallback tests that BuildPackageList falls back
+// to package.json when npm is not available.
+func TestNodeBuildPackageListFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	packageJSON := `{
+  "name": "test",
+  "dependencies": {
+    "express": "4.18.2"
+  }
+}`
+	err := os.WriteFile(filepath.Join(tmpDir, NodePackageFile), []byte(packageJSON), 0o600)
+	require.NoError(t, err)
+
+	// Remove npm from PATH
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", t.TempDir())
+	defer os.Setenv("PATH", origPath)
+
+	impl := &NodeModDefaultImpl{}
+	pkgs, err := impl.BuildPackageList(tmpDir)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 1)
+	require.Equal(t, "express", pkgs[0].Name)
+	require.Equal(t, "4.18.2", pkgs[0].Version)
+}
+
+// TestNodeModuleOpenAndConvert tests the full flow: create a fixture
+// directory, open the module, and convert to SPDX packages.
+func TestNodeModuleOpenAndConvert(t *testing.T) {
+	tmpDir := t.TempDir()
+	packageJSON := `{
+  "name": "test-project",
+  "version": "1.0.0",
+  "dependencies": {
+    "express": "4.18.2",
+    "@types/node": "18.11.9"
+  }
+}`
+	err := os.WriteFile(filepath.Join(tmpDir, NodePackageFile), []byte(packageJSON), 0o600)
+	require.NoError(t, err)
+
+	// Use empty PATH to force fallback
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", t.TempDir())
+	defer os.Setenv("PATH", origPath)
+
+	mod, err := NewNodeModuleFromPath(tmpDir)
+	require.NoError(t, err)
+	require.NoError(t, mod.Open())
+	require.Len(t, mod.Packages, 2)
+
+	for _, nodePkg := range mod.Packages {
+		spdxPkg, err := nodePkg.ToSPDXPackage()
+		require.NoError(t, err)
+		require.NotEmpty(t, spdxPkg.Name)
+		require.NotEmpty(t, spdxPkg.Version)
+		require.Contains(t, spdxPkg.DownloadLocation, "https://registry.npmjs.org/")
+		require.NotEmpty(t, spdxPkg.ID)
+
+		// Verify purl
+		require.NotEmpty(t, spdxPkg.ExternalRefs)
+		found := false
+		for _, ref := range spdxPkg.ExternalRefs {
+			if ref.Type == "purl" {
+				require.Contains(t, ref.Locator, "pkg:npm/")
+				found = true
+			}
+		}
+		require.True(t, found, "expected purl external ref for %s", nodePkg.Name)
+	}
+}
+
+// TestNodeScopedPackageDownloadURL verifies that scoped packages produce
+// correct npm download URLs.
+func TestNodeScopedPackageDownloadURL(t *testing.T) {
+	pkg := &NodePackage{Name: "@babel/core", Version: "7.20.12"}
+	spdxPkg, err := pkg.ToSPDXPackage()
+	require.NoError(t, err)
+	require.Equal(t,
+		"https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
+		spdxPkg.DownloadLocation,
+	)
+}
+
+// TestNodeDetectionInPackageFromDirectory tests that PackageFromDirectory
+// detects package.json and processes it.
+func TestNodeDetectionInPackageFromDirectory(t *testing.T) { //nolint:dupl // test structure mirrors python test but tests different language
+	tmpDir := t.TempDir()
+	packageJSON := `{
+  "name": "e2e-test",
+  "dependencies": {
+    "lodash": "4.17.21"
+  }
+}`
+	err := os.WriteFile(filepath.Join(tmpDir, NodePackageFile), []byte(packageJSON), 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "index.js"), []byte("console.log('hi')"), 0o600)
+	require.NoError(t, err)
+
+	// Use empty PATH to force fallback
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", t.TempDir())
+	defer os.Setenv("PATH", origPath)
+
+	sut := NewSPDX()
+	sut.Options().ProcessGoModules = false
+	sut.Options().ProcessPythonModules = false
+	sut.Options().ProcessRustModules = false
+	sut.Options().ProcessNodeModules = true
+	sut.Options().ScanLicenses = false
+
+	pkg, err := sut.PackageFromDirectory(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, pkg)
+
+	// Should have a DEPENDS_ON relationship for lodash
+	rels := *pkg.GetRelationships()
+	foundLodash := false
+	for _, rel := range rels {
+		if rel.Type == DEPENDS_ON && rel.Peer != nil && rel.Peer.GetName() == "lodash" {
+			foundLodash = true
+		}
+	}
+	require.True(t, foundLodash, "expected DEPENDS_ON relationship for lodash")
+}
+
+// TestNodeBuildPackageListWithNpm tests the npm path when npm is available.
+func TestNodeBuildPackageListWithNpm(t *testing.T) {
+	if _, err := exec.LookPath("npm"); err != nil {
+		t.Skip("npm not available, skipping npm-based test")
+	}
+
+	// Create a minimal node project and install a dependency
+	tmpDir := t.TempDir()
+	packageJSON := `{
+  "name": "e2e-npm-test",
+  "version": "1.0.0",
+  "dependencies": {}
+}`
+	err := os.WriteFile(filepath.Join(tmpDir, NodePackageFile), []byte(packageJSON), 0o600)
+	require.NoError(t, err)
+
+	impl := &NodeModDefaultImpl{}
+	pkgs, err := impl.BuildPackageList(tmpDir)
+	require.NoError(t, err)
+	// A project with no deps should return an empty list.
+	// The main point is that npm ls runs without error.
+	require.Empty(t, pkgs, "project with no dependencies should produce an empty package list")
+}

--- a/pkg/spdx/nodemod_test.go
+++ b/pkg/spdx/nodemod_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeToSPDXPackage(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		pkg         NodePackage
+		shouldError bool
+		checkDL     string // substring to check in DownloadLocation
+	}{
+		{
+			name:    "unscoped package",
+			pkg:     NodePackage{Name: "express", Version: "4.18.2"},
+			checkDL: "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+		},
+		{
+			name:    "scoped package",
+			pkg:     NodePackage{Name: "@types/node", Version: "18.11.9"},
+			checkDL: "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+		},
+		{
+			name: "package with no version",
+			pkg:  NodePackage{Name: "lodash", Version: ""},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spdxPackage, err := tc.pkg.ToSPDXPackage()
+			if tc.shouldError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.pkg.Name, spdxPackage.Name)
+			require.Equal(t, tc.pkg.Version, spdxPackage.Version)
+			if tc.checkDL != "" {
+				require.Equal(t, tc.checkDL, spdxPackage.DownloadLocation)
+			}
+		})
+	}
+}
+
+func TestNodePackageURL(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		pkg      NodePackage
+		expected string
+	}{
+		{
+			name:     "unscoped package",
+			pkg:      NodePackage{Name: "express", Version: "4.18.2"},
+			expected: "pkg:npm/express@4.18.2",
+		},
+		{
+			name:     "scoped package",
+			pkg:      NodePackage{Name: "@types/node", Version: "18.11.9"},
+			expected: "pkg:npm/%40types/node@18.11.9",
+		},
+		{
+			name:     "no name",
+			pkg:      NodePackage{Name: "", Version: "1.0.0"},
+			expected: "",
+		},
+		{
+			name:     "no version",
+			pkg:      NodePackage{Name: "lodash", Version: ""},
+			expected: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.pkg.PackageURL())
+		})
+	}
+}

--- a/pkg/spdx/pythonmod.go
+++ b/pkg/spdx/pythonmod.go
@@ -1,0 +1,483 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdx
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/nozzle/throttler"
+	purl "github.com/package-url/packageurl-go"
+	"github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/release-utils/helpers"
+	"sigs.k8s.io/release-utils/http"
+
+	"sigs.k8s.io/bom/pkg/license"
+)
+
+const (
+	pythonDownloadDir      = spdxTempDir + "/python-scanner"
+	PythonRequirementsFile = "requirements.txt"
+	PythonSetupFile        = "setup.py"
+	PythonPyprojectFile    = "pyproject.toml"
+	PythonPipfile          = "Pipfile"
+)
+
+// requirementRegexp matches lines like "package==1.2.3" in requirements.txt.
+var requirementRegexp = regexp.MustCompile(`^([a-zA-Z0-9_-]+)==(\S+)`)
+
+// NewPythonModuleFromPath returns a new python module from the specified path.
+func NewPythonModuleFromPath(path string) (*PythonModule, error) {
+	mod := NewPythonModule()
+	mod.opts.Path = path
+	return mod, nil
+}
+
+// NewPythonModule creates a new PythonModule with default options and implementation.
+func NewPythonModule() *PythonModule {
+	return &PythonModule{
+		opts: &PythonModuleOptions{},
+		impl: &PythonModDefaultImpl{},
+	}
+}
+
+// PythonModule abstracts the python module data of a project.
+type PythonModule struct {
+	impl     PythonModImplementation
+	opts     *PythonModuleOptions
+	Packages []*PythonPackage
+}
+
+// PythonModuleOptions are the options for the python module scanner.
+type PythonModuleOptions struct {
+	Path         string // Path to the dir where requirements.txt (or similar) resides
+	ScanLicenses bool   // Scan licenses from every possible place unless false
+}
+
+// Options returns a pointer to the module options set.
+func (mod *PythonModule) Options() *PythonModuleOptions {
+	return mod.opts
+}
+
+// SetScanLicenses sets the ScanLicenses option on the module.
+func (mod *PythonModule) SetScanLicenses(v bool) {
+	mod.opts.ScanLicenses = v
+}
+
+// GetPackageConverters returns the module's packages as spdxPackageConverter interfaces.
+func (mod *PythonModule) GetPackageConverters() []spdxPackageConverter {
+	converters := make([]spdxPackageConverter, len(mod.Packages))
+	for i, pkg := range mod.Packages {
+		converters[i] = pkg
+	}
+	return converters
+}
+
+// PythonPackage contains basic package data we need.
+type PythonPackage struct {
+	TmpDir        bool
+	Name          string
+	Version       string
+	LocalDir      string
+	LicenseID     string
+	CopyrightText string
+}
+
+// ToSPDXPackage builds an SPDX package from the python package data.
+func (pkg *PythonPackage) ToSPDXPackage() (*Package, error) {
+	if pkg.Name == "" {
+		return nil, errors.New("python package name is empty")
+	}
+
+	downloadURL := fmt.Sprintf("https://pypi.org/project/%s/%s/", pkg.Name, pkg.Version)
+
+	spdxPackage := NewPackage()
+	spdxPackage.Options().Prefix = "pypi"
+	spdxPackage.Name = pkg.Name
+	spdxPackage.BuildID(pkg.Name, pkg.Version)
+	spdxPackage.DownloadLocation = downloadURL
+	spdxPackage.LicenseConcluded = pkg.LicenseID
+	spdxPackage.Version = pkg.Version
+	spdxPackage.CopyrightText = pkg.CopyrightText
+
+	if packageurl := pkg.PackageURL(); packageurl != "" {
+		spdxPackage.ExternalRefs = append(spdxPackage.ExternalRefs, ExternalRef{
+			Category: CatPackageManager,
+			Type:     "purl",
+			Locator:  packageurl,
+		})
+	}
+	return spdxPackage, nil
+}
+
+// PackageURL returns a purl if the python package has enough data to
+// generate one. If data is missing, it will return an empty string.
+func (pkg *PythonPackage) PackageURL() string {
+	if pkg.Name == "" || pkg.Version == "" {
+		return ""
+	}
+
+	return purl.NewPackageURL(
+		purl.TypePyPi, "", pkg.Name,
+		pkg.Version, nil, "",
+	).ToString()
+}
+
+// PythonModImplementation is the interface that the python module
+// scanner uses to interact with the system.
+type PythonModImplementation interface {
+	BuildPackageList(path string) ([]*PythonPackage, error)
+	DownloadPackage(*PythonPackage, *PythonModuleOptions, bool) error
+	RemoveDownloads([]*PythonPackage) error
+	LicenseReader() (*license.Reader, error)
+	ScanPackageLicense(*PythonPackage, *license.Reader, *PythonModuleOptions) error
+}
+
+// Open initializes the python module from the configured path.
+func (mod *PythonModule) Open() error {
+	pkgs, err := mod.impl.BuildPackageList(mod.opts.Path)
+	if err != nil {
+		return fmt.Errorf("building python package list: %w", err)
+	}
+	mod.Packages = pkgs
+	return nil
+}
+
+// RemoveDownloads cleans all downloads.
+func (mod *PythonModule) RemoveDownloads() error {
+	return mod.impl.RemoveDownloads(mod.Packages)
+}
+
+// ScanLicenses scans the licenses and populates the fields.
+func (mod *PythonModule) ScanLicenses() error {
+	if mod.Packages == nil {
+		return errors.New("unable to scan license files, package list is nil")
+	}
+
+	reader, err := mod.impl.LicenseReader()
+	if err != nil {
+		return fmt.Errorf("creating license scanner: %w", err)
+	}
+
+	logrus.Infof("Scanning licenses for %d python packages", len(mod.Packages))
+
+	// Create a new Throttler that will get parallelDownloads urls at a time
+	t := throttler.New(10, len(mod.Packages))
+	for _, pkg := range mod.Packages {
+		// Launch a goroutine to fetch the package contents
+		go func(curPkg *PythonPackage) {
+			logrus.WithField(
+				"package", curPkg.Name).Debugf(
+				"Downloading package (%d total)", len(mod.Packages),
+			)
+			defer t.Done(err)
+
+			// Download the package to a temp location
+			if curPkg.LocalDir == "" {
+				// Call download with no force in case local data is missing
+				if err2 := mod.impl.DownloadPackage(curPkg, mod.opts, false); err2 != nil {
+					// If we're unable to download the module we don't treat it as
+					// fatal, package will remain without license info but we go
+					// on scanning the rest of the packages.
+					logrus.WithField("package", curPkg.Name).Error(err2)
+					return
+				}
+			}
+
+			// Now that we are sure it's in the filesystem, scan the license
+			if err = mod.impl.ScanPackageLicense(curPkg, reader, mod.opts); err != nil {
+				logrus.WithField("package", curPkg.Name).Errorf(
+					"scanning package %s for licensing info", curPkg.Name,
+				)
+			}
+		}(pkg)
+		t.Throttle()
+	}
+
+	if t.Err() != nil {
+		return t.Err()
+	}
+
+	return nil
+}
+
+// PythonModDefaultImpl is the default implementation of PythonModImplementation.
+type PythonModDefaultImpl struct {
+	licenseReader *license.Reader
+}
+
+// BuildPackageList builds a list of python packages from the project at the given path.
+// It first tries to use pip to list installed packages. If pip is not available,
+// it falls back to parsing requirements.txt directly.
+func (di *PythonModDefaultImpl) BuildPackageList(path string) ([]*PythonPackage, error) {
+	pkgs := []*PythonPackage{}
+
+	// Log what manifest files we find
+	for _, f := range []string{PythonRequirementsFile, PythonSetupFile, PythonPyprojectFile, PythonPipfile} {
+		if helpers.Exists(filepath.Join(path, f)) {
+			logrus.Infof("Found python manifest file: %s", f)
+		}
+	}
+
+	// Try pip list --format=json first
+	pipBin, err := exec.LookPath("pip")
+	if err != nil {
+		// Also try pip3
+		pipBin, err = exec.LookPath("pip3")
+	}
+
+	if err == nil {
+		pkgs, err = di.buildPackageListFromPip(pipBin, path)
+		if err == nil {
+			logrus.Infof("Found %d packages from pip", len(pkgs))
+			return pkgs, nil
+		}
+		logrus.Warnf("pip list failed, falling back to requirements.txt parsing: %v", err)
+	} else {
+		logrus.Warn("pip not found in PATH, falling back to requirements.txt parsing")
+	}
+
+	// Fallback: parse requirements.txt directly
+	reqFile := filepath.Join(path, PythonRequirementsFile)
+	if !helpers.Exists(reqFile) {
+		return pkgs, fmt.Errorf("no %s found in %s and pip is not available", PythonRequirementsFile, path)
+	}
+
+	pkgs, err = di.parseRequirementsFile(reqFile)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", PythonRequirementsFile, err)
+	}
+
+	logrus.Infof("Found %d packages from %s", len(pkgs), PythonRequirementsFile)
+	return pkgs, nil
+}
+
+// buildPackageListFromPip runs pip list --format=json and parses the output.
+func (di *PythonModDefaultImpl) buildPackageListFromPip(pipBin, path string) ([]*PythonPackage, error) {
+	// Check if we have a requirements file to install from
+	reqFile := filepath.Join(path, PythonRequirementsFile)
+	if helpers.Exists(reqFile) {
+		logrus.Infof("Using pip to list packages from %s", reqFile)
+	}
+
+	cmd := exec.CommandContext(context.TODO(), pipBin, "list", "--format=json") // #nosec G204
+	cmd.Dir = path
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("running pip list: %w", err)
+	}
+
+	type pipPackage struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+
+	var pipPkgs []pipPackage
+	if err := json.Unmarshal(output, &pipPkgs); err != nil {
+		return nil, fmt.Errorf("parsing pip list output: %w", err)
+	}
+
+	pkgs := make([]*PythonPackage, 0, len(pipPkgs))
+	for _, p := range pipPkgs {
+		logrus.Infof(" > %s@%s", p.Name, p.Version)
+		pkgs = append(pkgs, &PythonPackage{
+			Name:    p.Name,
+			Version: p.Version,
+		})
+	}
+	return pkgs, nil
+}
+
+// parseRequirementsFile reads a requirements.txt and extracts pinned dependencies.
+func (di *PythonModDefaultImpl) parseRequirementsFile(reqFile string) ([]*PythonPackage, error) {
+	data, err := os.ReadFile(reqFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", reqFile, err)
+	}
+
+	pkgs := []*PythonPackage{}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		// Skip comments and empty lines
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "-") {
+			continue
+		}
+
+		matches := requirementRegexp.FindStringSubmatch(line)
+		if len(matches) == 3 {
+			logrus.Infof(" > %s@%s", matches[1], matches[2])
+			pkgs = append(pkgs, &PythonPackage{
+				Name:    matches[1],
+				Version: matches[2],
+			})
+		}
+	}
+	return pkgs, nil
+}
+
+// DownloadPackage downloads a python package source from PyPI and extracts it
+// to a temporary directory. It sets pkg.LocalDir to the extracted location.
+func (di *PythonModDefaultImpl) DownloadPackage(pkg *PythonPackage, _ *PythonModuleOptions, force bool) error {
+	if pkg.LocalDir != "" && helpers.Exists(pkg.LocalDir) && !force {
+		logrus.WithField("package", pkg.Name).Infof("Not downloading %s as it already has local data", pkg.Name)
+		return nil
+	}
+
+	logrus.WithField("package", pkg.Name).Debugf("Downloading package %s@%s", pkg.Name, pkg.Version)
+
+	// Create temp directory
+	if !helpers.Exists(filepath.Join(os.TempDir(), pythonDownloadDir)) {
+		if err := os.MkdirAll(
+			filepath.Join(os.TempDir(), pythonDownloadDir), os.FileMode(0o755),
+		); err != nil {
+			return fmt.Errorf("creating parent tmpdir: %w", err)
+		}
+	}
+
+	tmpDir, err := os.MkdirTemp(filepath.Join(os.TempDir(), pythonDownloadDir), "package-download-")
+	if err != nil {
+		return fmt.Errorf("creating temporary dir: %w", err)
+	}
+
+	// Query the PyPI JSON API to find the sdist download URL
+	pypiURL := fmt.Sprintf("https://pypi.org/pypi/%s/%s/json", pkg.Name, pkg.Version)
+	agent := http.NewAgent()
+	data, err := agent.Get(pypiURL)
+	if err != nil {
+		return fmt.Errorf("querying PyPI API for %s@%s (%s): %w", pkg.Name, pkg.Version, pypiURL, err)
+	}
+
+	// Parse the PyPI API response to find sdist URL
+	sdistURL, err := parsePyPIResponse(data)
+	if err != nil {
+		return fmt.Errorf("parsing PyPI response for %s@%s: %w", pkg.Name, pkg.Version, err)
+	}
+
+	// Download the sdist tarball
+	tarballData, err := agent.Get(sdistURL)
+	if err != nil {
+		return fmt.Errorf("downloading sdist for %s from %s: %w", pkg.Name, sdistURL, err)
+	}
+
+	// Extract the tarball
+	if err := extractTarGz(tarballData, tmpDir); err != nil {
+		return fmt.Errorf("extracting sdist tarball for %s: %w", pkg.Name, err)
+	}
+
+	logrus.WithField("package", pkg.Name).Infof(
+		"Python package %s (version %s) downloaded to %s", pkg.Name, pkg.Version, tmpDir,
+	)
+	pkg.LocalDir = tmpDir
+	pkg.TmpDir = true
+	return nil
+}
+
+// parsePyPIResponse parses the PyPI JSON API response and returns the sdist download URL.
+func parsePyPIResponse(data []byte) (string, error) {
+	var response struct {
+		URLs []struct {
+			PackageType string `json:"packagetype"`
+			URL         string `json:"url"`
+		} `json:"urls"`
+	}
+
+	if err := json.Unmarshal(data, &response); err != nil {
+		return "", fmt.Errorf("unmarshaling PyPI response: %w", err)
+	}
+
+	// Look for sdist first
+	for _, u := range response.URLs {
+		if u.PackageType == "sdist" {
+			return u.URL, nil
+		}
+	}
+
+	// Fallback to any available URL
+	if len(response.URLs) > 0 {
+		return response.URLs[0].URL, nil
+	}
+
+	return "", errors.New("no download URL found in PyPI response")
+}
+
+// RemoveDownloads takes a list of packages and removes their downloads.
+func (di *PythonModDefaultImpl) RemoveDownloads(packageList []*PythonPackage) error {
+	for _, pkg := range packageList {
+		if pkg.Name != "" && helpers.Exists(pkg.LocalDir) && pkg.TmpDir {
+			if err := os.RemoveAll(pkg.LocalDir); err != nil {
+				return fmt.Errorf("removing package data: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// LicenseReader returns a license reader.
+func (di *PythonModDefaultImpl) LicenseReader() (*license.Reader, error) {
+	if di.licenseReader == nil {
+		opts := license.DefaultReaderOptions
+		opts.CacheDir = filepath.Join(os.TempDir(), spdxLicenseDlCache)
+		opts.LicenseDir = filepath.Join(os.TempDir(), spdxLicenseData)
+		if !helpers.Exists(opts.CacheDir) {
+			if err := os.MkdirAll(opts.CacheDir, os.FileMode(0o755)); err != nil {
+				return nil, fmt.Errorf("creating dir: %w", err)
+			}
+		}
+		reader, err := license.NewReaderWithOptions(opts)
+		if err != nil {
+			return nil, fmt.Errorf("creating reader: %w", err)
+		}
+
+		di.licenseReader = reader
+	}
+	return di.licenseReader, nil
+}
+
+// ScanPackageLicense scans a package for licensing info.
+func (di *PythonModDefaultImpl) ScanPackageLicense(
+	pkg *PythonPackage, reader *license.Reader, _ *PythonModuleOptions,
+) error {
+	dir := pkg.LocalDir
+	if dir == "" {
+		return fmt.Errorf("package %s has no local directory to scan", pkg.Name)
+	}
+
+	licenseResult, err := reader.ReadTopLicense(dir)
+	if err != nil {
+		return fmt.Errorf("scanning package %s for licensing information: %w", pkg.Name, err)
+	}
+
+	if licenseResult != nil {
+		logrus.Debugf(
+			"Package %s license is %s", pkg.Name,
+			licenseResult.License.LicenseID,
+		)
+		pkg.LicenseID = licenseResult.License.LicenseID
+		pkg.CopyrightText = licenseResult.Text
+	} else {
+		logrus.Warnf("Could not find licensing information for package %s", pkg.Name)
+	}
+	return nil
+}

--- a/pkg/spdx/pythonmod_e2e_test.go
+++ b/pkg/spdx/pythonmod_e2e_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdx
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPythonBuildPackageListFromRequirements tests the fallback path that
+// parses requirements.txt directly without needing pip installed.
+func TestPythonBuildPackageListFromRequirements(t *testing.T) {
+	// Create temp directory with a requirements.txt
+	tmpDir := t.TempDir()
+	reqContent := `# This is a comment
+requests==2.28.1
+flask==2.2.2
+numpy==1.23.5
+
+# Inline comments and flags should be skipped
+-r other-requirements.txt
+gunicorn==20.1.0
+`
+	err := os.WriteFile(filepath.Join(tmpDir, PythonRequirementsFile), []byte(reqContent), 0o600)
+	require.NoError(t, err)
+
+	impl := &PythonModDefaultImpl{}
+	pkgs, err := impl.parseRequirementsFile(filepath.Join(tmpDir, PythonRequirementsFile))
+	require.NoError(t, err)
+	require.Len(t, pkgs, 4)
+
+	// Verify the parsed packages
+	expected := map[string]string{
+		"requests": "2.28.1",
+		"flask":    "2.2.2",
+		"numpy":    "1.23.5",
+		"gunicorn": "20.1.0",
+	}
+	for _, pkg := range pkgs {
+		ver, ok := expected[pkg.Name]
+		require.True(t, ok, "unexpected package: %s", pkg.Name)
+		require.Equal(t, ver, pkg.Version)
+	}
+}
+
+// TestPythonBuildPackageListFallback tests that BuildPackageList falls back
+// to requirements.txt parsing when pip is not available (or fails).
+func TestPythonBuildPackageListFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	reqContent := `django==4.1.4
+celery==5.2.7
+`
+	err := os.WriteFile(filepath.Join(tmpDir, PythonRequirementsFile), []byte(reqContent), 0o600)
+	require.NoError(t, err)
+
+	// Simulate pip not being available by using a PATH with no pip
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", t.TempDir()) // empty dir, no pip binary
+	defer os.Setenv("PATH", origPath)
+
+	impl := &PythonModDefaultImpl{}
+	pkgs, err := impl.BuildPackageList(tmpDir)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+	require.Equal(t, "django", pkgs[0].Name)
+	require.Equal(t, "4.1.4", pkgs[0].Version)
+	require.Equal(t, "celery", pkgs[1].Name)
+	require.Equal(t, "5.2.7", pkgs[1].Version)
+}
+
+// TestPythonModuleOpenAndConvert tests the full flow: create a fixture
+// directory, open the module, and convert all packages to SPDX packages.
+func TestPythonModuleOpenAndConvert(t *testing.T) {
+	tmpDir := t.TempDir()
+	reqContent := `requests==2.28.1
+flask==2.2.2
+`
+	err := os.WriteFile(filepath.Join(tmpDir, PythonRequirementsFile), []byte(reqContent), 0o600)
+	require.NoError(t, err)
+
+	// Use empty PATH to force fallback to requirements.txt parsing
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", t.TempDir())
+	defer os.Setenv("PATH", origPath)
+
+	mod, err := NewPythonModuleFromPath(tmpDir)
+	require.NoError(t, err)
+	require.NoError(t, mod.Open())
+	require.Len(t, mod.Packages, 2)
+
+	// Convert to SPDX packages
+	for _, pyPkg := range mod.Packages {
+		spdxPkg, err := pyPkg.ToSPDXPackage()
+		require.NoError(t, err)
+		require.NotEmpty(t, spdxPkg.Name)
+		require.NotEmpty(t, spdxPkg.Version)
+		require.Contains(t, spdxPkg.DownloadLocation, "https://pypi.org/project/")
+		require.NotEmpty(t, spdxPkg.ID, "SPDX ID should be set")
+
+		// Verify purl external ref
+		require.NotEmpty(t, spdxPkg.ExternalRefs)
+		found := false
+		for _, ref := range spdxPkg.ExternalRefs {
+			if ref.Type == "purl" {
+				require.Contains(t, ref.Locator, "pkg:pypi/")
+				found = true
+			}
+		}
+		require.True(t, found, "expected purl external ref")
+	}
+}
+
+// TestPythonDetectionInPackageFromDirectory tests that PackageFromDirectory
+// detects Python manifests and processes them.
+func TestPythonDetectionInPackageFromDirectory(t *testing.T) { //nolint:dupl // test structure mirrors node test but tests different language
+	tmpDir := t.TempDir()
+	reqContent := `requests==2.28.1
+`
+	err := os.WriteFile(filepath.Join(tmpDir, PythonRequirementsFile), []byte(reqContent), 0o600)
+	require.NoError(t, err)
+
+	// Also need at least one file in the dir for PackageFromDirectory to work
+	err = os.WriteFile(filepath.Join(tmpDir, "main.py"), []byte("print('hello')"), 0o600)
+	require.NoError(t, err)
+
+	// Use empty PATH to force fallback parsing
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", t.TempDir())
+	defer os.Setenv("PATH", origPath)
+
+	sut := NewSPDX()
+	sut.Options().ProcessGoModules = false
+	sut.Options().ProcessNodeModules = false
+	sut.Options().ProcessRustModules = false
+	sut.Options().ProcessPythonModules = true
+	sut.Options().ScanLicenses = false
+
+	pkg, err := sut.PackageFromDirectory(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, pkg)
+
+	// Should have at least one DEPENDS_ON relationship for requests
+	rels := *pkg.GetRelationships()
+	foundRequests := false
+	for _, rel := range rels {
+		if rel.Type == DEPENDS_ON && rel.Peer != nil && rel.Peer.GetName() == "requests" {
+			foundRequests = true
+		}
+	}
+	require.True(t, foundRequests, "expected DEPENDS_ON relationship for requests package")
+}
+
+// TestPythonManifestDetection tests hasPythonManifest with various files.
+func TestPythonManifestDetection(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		files    []string
+		expected bool
+	}{
+		{"requirements.txt", []string{PythonRequirementsFile}, true},
+		{"setup.py", []string{PythonSetupFile}, true},
+		{"pyproject.toml", []string{PythonPyprojectFile}, true},
+		{"Pipfile", []string{PythonPipfile}, true},
+		{"no python files", []string{"main.go"}, false},
+		{"empty directory", []string{}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			for _, f := range tc.files {
+				err := os.WriteFile(filepath.Join(tmpDir, f), []byte(""), 0o600)
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expected, hasPythonManifest(tmpDir))
+		})
+	}
+}
+
+// TestPythonBuildPackageListWithPip tests the pip path when pip is available.
+func TestPythonBuildPackageListWithPip(t *testing.T) {
+	if _, err := exec.LookPath("pip"); err != nil {
+		if _, err := exec.LookPath("pip3"); err != nil {
+			t.Skip("pip/pip3 not available, skipping pip-based test")
+		}
+	}
+
+	// pip list --format=json lists currently installed packages.
+	// We just verify it returns something without error.
+	impl := &PythonModDefaultImpl{}
+
+	// Use current directory (which likely has no requirements.txt but pip should still work)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	pipBin, err := exec.LookPath("pip")
+	if err != nil {
+		pipBin, err = exec.LookPath("pip3")
+		require.NoError(t, err, "neither pip nor pip3 found in PATH")
+	}
+
+	pkgs, err := impl.buildPackageListFromPip(pipBin, cwd)
+	require.NoError(t, err)
+	// pip list should return at least pip itself
+	require.NotEmpty(t, pkgs, "pip list should return at least one package")
+
+	// Verify structure
+	for _, pkg := range pkgs {
+		require.NotEmpty(t, pkg.Name)
+		require.NotEmpty(t, pkg.Version)
+	}
+}

--- a/pkg/spdx/pythonmod_test.go
+++ b/pkg/spdx/pythonmod_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPythonToSPDXPackage(t *testing.T) {
+	for _, tc := range []struct {
+		pkg         PythonPackage
+		shouldError bool
+	}{
+		// Valid package
+		{PythonPackage{Name: "requests", Version: "2.28.1"}, false},
+		// Package with no name should error
+		{PythonPackage{Name: "", Version: "1.0.0"}, true},
+		// Package with no version is ok (version is optional for SPDX)
+		{PythonPackage{Name: "flask", Version: ""}, false},
+	} {
+		spdxPackage, err := tc.pkg.ToSPDXPackage()
+		if tc.shouldError {
+			require.Error(t, err)
+			continue
+		}
+
+		require.NoError(t, err)
+		require.Equal(t, tc.pkg.Name, spdxPackage.Name)
+		require.Equal(t, tc.pkg.Version, spdxPackage.Version)
+		require.Contains(t, spdxPackage.DownloadLocation, "https://pypi.org/project/")
+	}
+}
+
+func TestPythonPackageURL(t *testing.T) {
+	for _, tc := range []struct {
+		pkg      PythonPackage
+		expected string
+	}{
+		// Valid package
+		{PythonPackage{Name: "requests", Version: "2.28.1"}, "pkg:pypi/requests@2.28.1"},
+		// No name
+		{PythonPackage{Name: "", Version: "1.0.0"}, ""},
+		// No version
+		{PythonPackage{Name: "flask", Version: ""}, ""},
+	} {
+		require.Equal(t, tc.expected, tc.pkg.PackageURL())
+	}
+}

--- a/pkg/spdx/rustmod.go
+++ b/pkg/spdx/rustmod.go
@@ -1,0 +1,421 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdx
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	purl "github.com/package-url/packageurl-go"
+	"github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/release-utils/command"
+	"sigs.k8s.io/release-utils/helpers"
+	"sigs.k8s.io/release-utils/http"
+
+	"sigs.k8s.io/bom/pkg/license"
+)
+
+const (
+	rustDownloadDir   = spdxTempDir + "/rust-scanner"
+	RustCargoFile     = "Cargo.toml"
+	RustCargoLockFile = "Cargo.lock"
+
+	// cratesIORegistry is the crates.io source string in cargo metadata output.
+	cratesIORegistry = "registry+https://github.com/rust-lang/crates.io-index"
+
+	// Maximum file size for tar extraction (100MB).
+	maxRustExtractFileSize = 100 * 1024 * 1024
+)
+
+// NewRustModuleFromPath returns a new Rust module from the specified path.
+func NewRustModuleFromPath(path string) (*RustModule, error) {
+	mod := NewRustModule()
+	mod.opts.Path = path
+	return mod, nil
+}
+
+// NewRustModule creates a new RustModule with default options and implementation.
+func NewRustModule() *RustModule {
+	return &RustModule{
+		opts: &RustModuleOptions{},
+		impl: &RustModDefaultImpl{},
+	}
+}
+
+// RustModule abstracts the Rust module (Cargo) data of a project.
+type RustModule struct {
+	impl     RustModImplementation
+	opts     *RustModuleOptions
+	Packages []*RustPackage
+}
+
+// RustModuleOptions are the options for the Rust module scanner.
+type RustModuleOptions struct {
+	Path         string // Path to the dir where Cargo.toml resides
+	ScanLicenses bool   // Scan licenses from every possible place unless false
+}
+
+// Options returns a pointer to the module options set.
+func (mod *RustModule) Options() *RustModuleOptions {
+	return mod.opts
+}
+
+// SetScanLicenses sets the ScanLicenses option on the module.
+func (mod *RustModule) SetScanLicenses(v bool) {
+	mod.opts.ScanLicenses = v
+}
+
+// GetPackageConverters returns the module's packages as spdxPackageConverter interfaces.
+func (mod *RustModule) GetPackageConverters() []spdxPackageConverter {
+	converters := make([]spdxPackageConverter, len(mod.Packages))
+	for i, pkg := range mod.Packages {
+		converters[i] = pkg
+	}
+	return converters
+}
+
+// RustPackage holds basic package data we need for a Rust crate.
+type RustPackage struct {
+	TmpDir        bool
+	Name          string
+	Version       string
+	LocalDir      string
+	LicenseID     string
+	CopyrightText string
+}
+
+// GetName returns the package name.
+func (pkg *RustPackage) GetName() string { return pkg.Name }
+
+// ToSPDXPackage builds a spdx package from the Rust package data.
+func (pkg *RustPackage) ToSPDXPackage() (*Package, error) {
+	downloadURL := fmt.Sprintf(
+		"https://crates.io/api/v1/crates/%s/%s/download",
+		pkg.Name, pkg.Version,
+	)
+
+	spdxPackage := NewPackage()
+	spdxPackage.Options().Prefix = "cargo"
+	spdxPackage.Name = pkg.Name
+	spdxPackage.BuildID(pkg.Name, pkg.Version)
+	spdxPackage.DownloadLocation = downloadURL
+	spdxPackage.LicenseConcluded = pkg.LicenseID
+	spdxPackage.Version = pkg.Version
+	spdxPackage.CopyrightText = pkg.CopyrightText
+
+	if packageurl := pkg.PackageURL(); packageurl != "" {
+		spdxPackage.ExternalRefs = append(spdxPackage.ExternalRefs, ExternalRef{
+			Category: CatPackageManager,
+			Type:     "purl",
+			Locator:  packageurl,
+		})
+	}
+	return spdxPackage, nil
+}
+
+// PackageURL returns a purl if the Rust package has enough data to generate
+// one. If data is missing, it will return an empty string.
+func (pkg *RustPackage) PackageURL() string {
+	if pkg.Name == "" || pkg.Version == "" {
+		return ""
+	}
+
+	return purl.NewPackageURL(
+		purl.TypeCargo, "", pkg.Name,
+		pkg.Version, nil, "",
+	).ToString()
+}
+
+// RustModImplementation is the interface that the Rust module scanner uses.
+type RustModImplementation interface {
+	BuildPackageList(path string) ([]*RustPackage, error)
+	DownloadPackage(*RustPackage, *RustModuleOptions, bool) error
+	RemoveDownloads([]*RustPackage) error
+	LicenseReader() (*license.Reader, error)
+	ScanPackageLicense(*RustPackage, *license.Reader, *RustModuleOptions) error
+}
+
+// Open initializes the Rust module from the configured path.
+func (mod *RustModule) Open() error {
+	pkgs, err := mod.impl.BuildPackageList(mod.opts.Path)
+	if err != nil {
+		return fmt.Errorf("building Rust package list: %w", err)
+	}
+	mod.Packages = pkgs
+	return nil
+}
+
+// RemoveDownloads cleans all downloads.
+func (mod *RustModule) RemoveDownloads() error {
+	return mod.impl.RemoveDownloads(mod.Packages)
+}
+
+// ScanLicenses scans the licenses and populates the fields.
+func (mod *RustModule) ScanLicenses() error {
+	if mod.Packages == nil {
+		return errors.New("unable to scan license files, package list is nil")
+	}
+
+	reader, err := mod.impl.LicenseReader()
+	if err != nil {
+		return fmt.Errorf("creating license scanner: %w", err)
+	}
+
+	return scanPackageLicenses(
+		mod.Packages, "Rust", reader,
+		func(pkg *RustPackage) error {
+			return mod.impl.DownloadPackage(pkg, mod.opts, false)
+		},
+		func(pkg *RustPackage, r *license.Reader) error {
+			return mod.impl.ScanPackageLicense(pkg, r, mod.opts)
+		},
+	)
+}
+
+// RustModDefaultImpl is the default implementation of RustModImplementation.
+type RustModDefaultImpl struct {
+	licenseReader *license.Reader
+}
+
+// cargoMetadataOutput represents the JSON output of `cargo metadata`.
+type cargoMetadataOutput struct {
+	Packages []cargoMetadataPackage `json:"packages"`
+}
+
+// cargoMetadataPackage represents a single package in cargo metadata output.
+type cargoMetadataPackage struct {
+	Name    string  `json:"name"`
+	Version string  `json:"version"`
+	Source  *string `json:"source"`
+}
+
+// BuildPackageList runs cargo metadata and builds a list of Rust packages.
+func (di *RustModDefaultImpl) BuildPackageList(path string) ([]*RustPackage, error) {
+	cargoBin, err := exec.LookPath("cargo")
+	if err != nil {
+		return nil, errors.New("unable to build Rust package list, cargo executable not found")
+	}
+
+	cargoRun := command.NewWithWorkDir(
+		path, cargoBin, "metadata", "--format-version", "1",
+	)
+	output, err := cargoRun.RunSilentSuccessOutput()
+	if err != nil {
+		return nil, fmt.Errorf("while calling cargo metadata to get dependencies: %w", err)
+	}
+
+	metadata := &cargoMetadataOutput{}
+	if err := json.Unmarshal([]byte(output.Output()), metadata); err != nil {
+		return nil, fmt.Errorf("parsing cargo metadata output: %w", err)
+	}
+
+	pkgs := make([]*RustPackage, 0, len(metadata.Packages))
+	for _, p := range metadata.Packages {
+		// Skip workspace root packages (source is null for local packages)
+		if p.Source == nil {
+			continue
+		}
+
+		// Only include packages from crates.io
+		if !strings.Contains(*p.Source, cratesIORegistry) {
+			logrus.Debugf("Skipping non-crates.io package %s (source: %s)", p.Name, *p.Source)
+			continue
+		}
+
+		pkgs = append(pkgs, &RustPackage{
+			Name:    p.Name,
+			Version: p.Version,
+		})
+	}
+
+	logrus.Infof("Found %d Rust packages from cargo metadata", len(pkgs))
+	return pkgs, nil
+}
+
+// DownloadPackage takes a RustPackage, downloads it from crates.io, and sets
+// the download dir in the LocalDir field.
+func (di *RustModDefaultImpl) DownloadPackage(pkg *RustPackage, _ *RustModuleOptions, force bool) error {
+	if pkg.LocalDir != "" && helpers.Exists(pkg.LocalDir) && !force {
+		logrus.WithField("package", pkg.Name).Infof("Not downloading %s as it already has local data", pkg.Name)
+		return nil
+	}
+
+	logrus.WithField("package", pkg.Name).Debugf("Downloading package %s@%s", pkg.Name, pkg.Version)
+
+	// Create temp directory
+	if !helpers.Exists(filepath.Join(os.TempDir(), rustDownloadDir)) {
+		if err := os.MkdirAll(
+			filepath.Join(os.TempDir(), rustDownloadDir), os.FileMode(0o755),
+		); err != nil {
+			return fmt.Errorf("creating parent tmpdir: %w", err)
+		}
+	}
+
+	tmpDir, err := os.MkdirTemp(filepath.Join(os.TempDir(), rustDownloadDir), "package-download-")
+	if err != nil {
+		return fmt.Errorf("creating temporary dir: %w", err)
+	}
+
+	downloadURL := fmt.Sprintf(
+		"https://crates.io/api/v1/crates/%s/%s/download",
+		pkg.Name, pkg.Version,
+	)
+
+	// Download from crates.io using release-utils http agent
+	agent := http.NewAgent()
+	data, err := agent.Get(downloadURL)
+	if err != nil {
+		return fmt.Errorf("downloading %s from crates.io (%s): %w", pkg.Name, downloadURL, err)
+	}
+
+	// Extract gzipped tarball to temp directory
+	if err := extractTarGz(data, tmpDir); err != nil {
+		return fmt.Errorf("extracting crate tarball: %w", err)
+	}
+
+	logrus.WithField("package", pkg.Name).Infof("Rust Package %s (version %s) downloaded to %s", pkg.Name, pkg.Version, tmpDir)
+	pkg.LocalDir = tmpDir
+	pkg.TmpDir = true
+	return nil
+}
+
+// extractTarGz extracts a gzipped tar archive to the destination directory.
+// Source tarballs typically have format: package-version/path, so we strip
+// the first component.
+func extractTarGz(data []byte, destDir string) error {
+	gzReader, err := gzip.NewReader(strings.NewReader(string(data)))
+	if err != nil {
+		return fmt.Errorf("opening gzip reader: %w", err)
+	}
+	defer gzReader.Close()
+
+	tarReader := tar.NewReader(gzReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar entry: %w", err)
+		}
+
+		// Strip the first path component (package-version/)
+		parts := strings.SplitN(header.Name, "/", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		destPath := filepath.Join(destDir, parts[1])
+
+		// Validate path to prevent path traversal
+		if !strings.HasPrefix(filepath.Clean(destPath), filepath.Clean(destDir)) {
+			continue
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(destPath, 0o755); err != nil {
+				return fmt.Errorf("creating directory: %w", err)
+			}
+		case tar.TypeReg:
+			// Create parent directories
+			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+				return fmt.Errorf("creating parent directory: %w", err)
+			}
+
+			outFile, err := os.Create(destPath)
+			if err != nil {
+				return fmt.Errorf("creating file: %w", err)
+			}
+
+			limited := io.LimitReader(tarReader, maxRustExtractFileSize)
+			_, err = io.Copy(outFile, limited)
+			outFile.Close()
+			if err != nil {
+				return fmt.Errorf("extracting file: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// RemoveDownloads takes a list of packages and removes their downloads.
+func (di *RustModDefaultImpl) RemoveDownloads(packageList []*RustPackage) error {
+	for _, pkg := range packageList {
+		if pkg.Name != "" && helpers.Exists(pkg.LocalDir) && pkg.TmpDir {
+			if err := os.RemoveAll(pkg.LocalDir); err != nil {
+				return fmt.Errorf("removing package data: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// LicenseReader returns a license reader.
+func (di *RustModDefaultImpl) LicenseReader() (*license.Reader, error) {
+	if di.licenseReader == nil {
+		opts := license.DefaultReaderOptions
+		opts.CacheDir = filepath.Join(os.TempDir(), spdxLicenseDlCache)
+		opts.LicenseDir = filepath.Join(os.TempDir(), spdxLicenseData)
+		if !helpers.Exists(opts.CacheDir) {
+			if err := os.MkdirAll(opts.CacheDir, os.FileMode(0o755)); err != nil {
+				return nil, fmt.Errorf("creating dir: %w", err)
+			}
+		}
+		reader, err := license.NewReaderWithOptions(opts)
+		if err != nil {
+			return nil, fmt.Errorf("creating reader: %w", err)
+		}
+
+		di.licenseReader = reader
+	}
+	return di.licenseReader, nil
+}
+
+// ScanPackageLicense scans a package for licensing info.
+func (di *RustModDefaultImpl) ScanPackageLicense(
+	pkg *RustPackage, reader *license.Reader, _ *RustModuleOptions,
+) error {
+	dir := pkg.LocalDir
+	if dir == "" {
+		return fmt.Errorf("package %s has no local directory to scan", pkg.Name)
+	}
+	licenseResult, err := reader.ReadTopLicense(dir)
+	if err != nil {
+		return fmt.Errorf("scanning package %s for licensing information: %w", pkg.Name, err)
+	}
+
+	if licenseResult != nil {
+		logrus.Debugf(
+			"Package %s license is %s", pkg.Name,
+			licenseResult.License.LicenseID,
+		)
+		pkg.LicenseID = licenseResult.License.LicenseID
+		pkg.CopyrightText = licenseResult.Text
+	} else {
+		logrus.Warnf("Could not find licensing information for package %s", pkg.Name)
+	}
+	return nil
+}

--- a/pkg/spdx/rustmod_e2e_test.go
+++ b/pkg/spdx/rustmod_e2e_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdx
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// requireCargo skips the test when cargo is not available.
+func requireCargo(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("cargo"); err != nil {
+		t.Skip("cargo not available, skipping cargo-based test")
+	}
+}
+
+// writeMinimalCargoProject creates a minimal Cargo project in dir so that
+// `cargo metadata` can succeed. The project depends on a single small crate.
+func writeMinimalCargoProject(t *testing.T, dir string) {
+	t.Helper()
+
+	cargoToml := `[package]
+name = "bom-e2e-test"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+itoa = "1.0"
+`
+	err := os.WriteFile(filepath.Join(dir, RustCargoFile), []byte(cargoToml), 0o600)
+	require.NoError(t, err)
+
+	// cargo metadata needs a src/main.rs to be happy
+	srcDir := filepath.Join(dir, "src")
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	err = os.WriteFile(filepath.Join(srcDir, "main.rs"), []byte("fn main() {}\n"), 0o600)
+	require.NoError(t, err)
+}
+
+// TestRustBuildPackageListWithCargo verifies that BuildPackageList runs
+// cargo metadata and returns packages.
+func TestRustBuildPackageListWithCargo(t *testing.T) {
+	requireCargo(t)
+
+	tmpDir := t.TempDir()
+	writeMinimalCargoProject(t, tmpDir)
+
+	impl := &RustModDefaultImpl{}
+	pkgs, err := impl.BuildPackageList(tmpDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, pkgs, "should find at least one dependency (itoa)")
+
+	// Verify itoa is in the list
+	foundItoa := false
+	for _, pkg := range pkgs {
+		require.NotEmpty(t, pkg.Name)
+		require.NotEmpty(t, pkg.Version)
+		if pkg.Name == "itoa" {
+			foundItoa = true
+		}
+	}
+	require.True(t, foundItoa, "expected to find itoa in Rust dependencies")
+}
+
+// TestRustBuildPackageListNoCargo verifies that BuildPackageList returns
+// an error when cargo is not on PATH.
+func TestRustBuildPackageListNoCargo(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeMinimalCargoProject(t, tmpDir)
+
+	// Remove cargo from PATH
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", t.TempDir())
+	defer os.Setenv("PATH", origPath)
+
+	impl := &RustModDefaultImpl{}
+	_, err := impl.BuildPackageList(tmpDir)
+	require.Error(t, err, "should fail when cargo is not available")
+	require.Contains(t, err.Error(), "cargo executable not found")
+}
+
+// TestRustModuleOpenAndConvert tests the full flow: create a fixture
+// project, open the module, and convert packages to SPDX packages.
+func TestRustModuleOpenAndConvert(t *testing.T) {
+	requireCargo(t)
+
+	tmpDir := t.TempDir()
+	writeMinimalCargoProject(t, tmpDir)
+
+	mod, err := NewRustModuleFromPath(tmpDir)
+	require.NoError(t, err)
+	require.NoError(t, mod.Open())
+	require.NotEmpty(t, mod.Packages, "should have at least one package")
+
+	for _, rustPkg := range mod.Packages {
+		spdxPkg, err := rustPkg.ToSPDXPackage()
+		require.NoError(t, err)
+		require.NotEmpty(t, spdxPkg.Name)
+		require.NotEmpty(t, spdxPkg.Version)
+		require.Contains(t, spdxPkg.DownloadLocation, "https://crates.io/api/v1/crates/")
+		require.NotEmpty(t, spdxPkg.ID, "SPDX ID should be set")
+
+		// Verify purl external ref
+		require.NotEmpty(t, spdxPkg.ExternalRefs)
+		found := false
+		for _, ref := range spdxPkg.ExternalRefs {
+			if ref.Type == "purl" {
+				require.Contains(t, ref.Locator, "pkg:cargo/")
+				found = true
+			}
+		}
+		require.True(t, found, "expected purl external ref for %s", rustPkg.Name)
+	}
+}
+
+// TestRustDetectionInPackageFromDirectory tests that PackageFromDirectory
+// detects Cargo.toml and processes it when cargo is available.
+func TestRustDetectionInPackageFromDirectory(t *testing.T) {
+	requireCargo(t)
+
+	tmpDir := t.TempDir()
+	writeMinimalCargoProject(t, tmpDir)
+
+	sut := NewSPDX()
+	sut.Options().ProcessGoModules = false
+	sut.Options().ProcessPythonModules = false
+	sut.Options().ProcessNodeModules = false
+	sut.Options().ProcessRustModules = true
+	sut.Options().ScanLicenses = false
+
+	pkg, err := sut.PackageFromDirectory(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, pkg)
+
+	// Should have at least one DEPENDS_ON relationship for itoa
+	rels := *pkg.GetRelationships()
+	foundItoa := false
+	for _, rel := range rels {
+		if rel.Type == DEPENDS_ON && rel.Peer != nil && rel.Peer.GetName() == "itoa" {
+			foundItoa = true
+		}
+	}
+	require.True(t, foundItoa, "expected DEPENDS_ON relationship for itoa package")
+}
+
+// TestRustPackageRemoveDownloads verifies cleanup of downloaded packages.
+func TestRustPackageRemoveDownloads(t *testing.T) {
+	// Create a fake downloaded package directory
+	tmpDir := t.TempDir()
+	fakeLocalDir := filepath.Join(tmpDir, "itoa-download")
+	require.NoError(t, os.MkdirAll(fakeLocalDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(fakeLocalDir, "Cargo.toml"), []byte("[package]"), 0o600))
+
+	pkgs := []*RustPackage{
+		{Name: "itoa", Version: "1.0.0", LocalDir: fakeLocalDir, TmpDir: true},
+		{Name: "serde", Version: "1.0.0", LocalDir: "", TmpDir: false}, // no local dir, should be a no-op
+	}
+
+	impl := &RustModDefaultImpl{}
+	require.NoError(t, impl.RemoveDownloads(pkgs))
+
+	// fakeLocalDir should have been cleaned up
+	_, err := os.Stat(fakeLocalDir)
+	require.True(t, os.IsNotExist(err), "expected download directory to be removed")
+}

--- a/pkg/spdx/rustmod_test.go
+++ b/pkg/spdx/rustmod_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRustToSPDXPackage(t *testing.T) {
+	for _, tc := range []struct {
+		pkg         RustPackage
+		shouldError bool
+	}{
+		// Valid package
+		{RustPackage{Name: "serde", Version: "1.0.152"}, false},
+		// Package with no version
+		{RustPackage{Name: "tokio", Version: ""}, false},
+	} {
+		spdxPackage, err := tc.pkg.ToSPDXPackage()
+		if tc.shouldError {
+			require.Error(t, err)
+			continue
+		}
+
+		require.NoError(t, err)
+		require.Equal(t, tc.pkg.Name, spdxPackage.Name)
+		require.Equal(t, tc.pkg.Version, spdxPackage.Version)
+		require.Contains(t, spdxPackage.DownloadLocation, "https://crates.io/api/v1/crates/")
+	}
+}
+
+func TestRustPackageURL(t *testing.T) {
+	for _, tc := range []struct {
+		pkg      RustPackage
+		expected string
+	}{
+		// Valid package
+		{RustPackage{Name: "serde", Version: "1.0.152"}, "pkg:cargo/serde@1.0.152"},
+		// No name
+		{RustPackage{Name: "", Version: "1.0.0"}, ""},
+		// No version
+		{RustPackage{Name: "tokio", Version: ""}, ""},
+	} {
+		require.Equal(t, tc.expected, tc.pkg.PackageURL())
+	}
+}

--- a/pkg/spdx/spdxfakes/fake_spdx_implementation.go
+++ b/pkg/spdx/spdxfakes/fake_spdx_implementation.go
@@ -89,6 +89,48 @@ type FakeSpdxImplementation struct {
 		result1 []*spdx.Package
 		result2 error
 	}
+	GetNodeDependenciesStub        func(string, *spdx.Options) ([]*spdx.Package, error)
+	getNodeDependenciesMutex       sync.RWMutex
+	getNodeDependenciesArgsForCall []struct {
+		arg1 string
+		arg2 *spdx.Options
+	}
+	getNodeDependenciesReturns struct {
+		result1 []*spdx.Package
+		result2 error
+	}
+	getNodeDependenciesReturnsOnCall map[int]struct {
+		result1 []*spdx.Package
+		result2 error
+	}
+	GetPythonDependenciesStub        func(string, *spdx.Options) ([]*spdx.Package, error)
+	getPythonDependenciesMutex       sync.RWMutex
+	getPythonDependenciesArgsForCall []struct {
+		arg1 string
+		arg2 *spdx.Options
+	}
+	getPythonDependenciesReturns struct {
+		result1 []*spdx.Package
+		result2 error
+	}
+	getPythonDependenciesReturnsOnCall map[int]struct {
+		result1 []*spdx.Package
+		result2 error
+	}
+	GetRustDependenciesStub        func(string, *spdx.Options) ([]*spdx.Package, error)
+	getRustDependenciesMutex       sync.RWMutex
+	getRustDependenciesArgsForCall []struct {
+		arg1 string
+		arg2 *spdx.Options
+	}
+	getRustDependenciesReturns struct {
+		result1 []*spdx.Package
+		result2 error
+	}
+	getRustDependenciesReturnsOnCall map[int]struct {
+		result1 []*spdx.Package
+		result2 error
+	}
 	IgnorePatternsStub        func(string, []string, bool) ([]gitignore.Pattern, error)
 	ignorePatternsMutex       sync.RWMutex
 	ignorePatternsArgsForCall []struct {
@@ -593,6 +635,201 @@ func (fake *FakeSpdxImplementation) GetGoDependenciesReturnsOnCall(i int, result
 		})
 	}
 	fake.getGoDependenciesReturnsOnCall[i] = struct {
+		result1 []*spdx.Package
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSpdxImplementation) GetNodeDependencies(arg1 string, arg2 *spdx.Options) ([]*spdx.Package, error) {
+	fake.getNodeDependenciesMutex.Lock()
+	ret, specificReturn := fake.getNodeDependenciesReturnsOnCall[len(fake.getNodeDependenciesArgsForCall)]
+	fake.getNodeDependenciesArgsForCall = append(fake.getNodeDependenciesArgsForCall, struct {
+		arg1 string
+		arg2 *spdx.Options
+	}{arg1, arg2})
+	stub := fake.GetNodeDependenciesStub
+	fakeReturns := fake.getNodeDependenciesReturns
+	fake.recordInvocation("GetNodeDependencies", []interface{}{arg1, arg2})
+	fake.getNodeDependenciesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeSpdxImplementation) GetNodeDependenciesCallCount() int {
+	fake.getNodeDependenciesMutex.RLock()
+	defer fake.getNodeDependenciesMutex.RUnlock()
+	return len(fake.getNodeDependenciesArgsForCall)
+}
+
+func (fake *FakeSpdxImplementation) GetNodeDependenciesCalls(stub func(string, *spdx.Options) ([]*spdx.Package, error)) {
+	fake.getNodeDependenciesMutex.Lock()
+	defer fake.getNodeDependenciesMutex.Unlock()
+	fake.GetNodeDependenciesStub = stub
+}
+
+func (fake *FakeSpdxImplementation) GetNodeDependenciesArgsForCall(i int) (string, *spdx.Options) {
+	fake.getNodeDependenciesMutex.RLock()
+	defer fake.getNodeDependenciesMutex.RUnlock()
+	argsForCall := fake.getNodeDependenciesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeSpdxImplementation) GetNodeDependenciesReturns(result1 []*spdx.Package, result2 error) {
+	fake.getNodeDependenciesMutex.Lock()
+	defer fake.getNodeDependenciesMutex.Unlock()
+	fake.GetNodeDependenciesStub = nil
+	fake.getNodeDependenciesReturns = struct {
+		result1 []*spdx.Package
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSpdxImplementation) GetNodeDependenciesReturnsOnCall(i int, result1 []*spdx.Package, result2 error) {
+	fake.getNodeDependenciesMutex.Lock()
+	defer fake.getNodeDependenciesMutex.Unlock()
+	fake.GetNodeDependenciesStub = nil
+	if fake.getNodeDependenciesReturnsOnCall == nil {
+		fake.getNodeDependenciesReturnsOnCall = make(map[int]struct {
+			result1 []*spdx.Package
+			result2 error
+		})
+	}
+	fake.getNodeDependenciesReturnsOnCall[i] = struct {
+		result1 []*spdx.Package
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSpdxImplementation) GetPythonDependencies(arg1 string, arg2 *spdx.Options) ([]*spdx.Package, error) {
+	fake.getPythonDependenciesMutex.Lock()
+	ret, specificReturn := fake.getPythonDependenciesReturnsOnCall[len(fake.getPythonDependenciesArgsForCall)]
+	fake.getPythonDependenciesArgsForCall = append(fake.getPythonDependenciesArgsForCall, struct {
+		arg1 string
+		arg2 *spdx.Options
+	}{arg1, arg2})
+	stub := fake.GetPythonDependenciesStub
+	fakeReturns := fake.getPythonDependenciesReturns
+	fake.recordInvocation("GetPythonDependencies", []interface{}{arg1, arg2})
+	fake.getPythonDependenciesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeSpdxImplementation) GetPythonDependenciesCallCount() int {
+	fake.getPythonDependenciesMutex.RLock()
+	defer fake.getPythonDependenciesMutex.RUnlock()
+	return len(fake.getPythonDependenciesArgsForCall)
+}
+
+func (fake *FakeSpdxImplementation) GetPythonDependenciesCalls(stub func(string, *spdx.Options) ([]*spdx.Package, error)) {
+	fake.getPythonDependenciesMutex.Lock()
+	defer fake.getPythonDependenciesMutex.Unlock()
+	fake.GetPythonDependenciesStub = stub
+}
+
+func (fake *FakeSpdxImplementation) GetPythonDependenciesArgsForCall(i int) (string, *spdx.Options) {
+	fake.getPythonDependenciesMutex.RLock()
+	defer fake.getPythonDependenciesMutex.RUnlock()
+	argsForCall := fake.getPythonDependenciesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeSpdxImplementation) GetPythonDependenciesReturns(result1 []*spdx.Package, result2 error) {
+	fake.getPythonDependenciesMutex.Lock()
+	defer fake.getPythonDependenciesMutex.Unlock()
+	fake.GetPythonDependenciesStub = nil
+	fake.getPythonDependenciesReturns = struct {
+		result1 []*spdx.Package
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSpdxImplementation) GetPythonDependenciesReturnsOnCall(i int, result1 []*spdx.Package, result2 error) {
+	fake.getPythonDependenciesMutex.Lock()
+	defer fake.getPythonDependenciesMutex.Unlock()
+	fake.GetPythonDependenciesStub = nil
+	if fake.getPythonDependenciesReturnsOnCall == nil {
+		fake.getPythonDependenciesReturnsOnCall = make(map[int]struct {
+			result1 []*spdx.Package
+			result2 error
+		})
+	}
+	fake.getPythonDependenciesReturnsOnCall[i] = struct {
+		result1 []*spdx.Package
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSpdxImplementation) GetRustDependencies(arg1 string, arg2 *spdx.Options) ([]*spdx.Package, error) {
+	fake.getRustDependenciesMutex.Lock()
+	ret, specificReturn := fake.getRustDependenciesReturnsOnCall[len(fake.getRustDependenciesArgsForCall)]
+	fake.getRustDependenciesArgsForCall = append(fake.getRustDependenciesArgsForCall, struct {
+		arg1 string
+		arg2 *spdx.Options
+	}{arg1, arg2})
+	stub := fake.GetRustDependenciesStub
+	fakeReturns := fake.getRustDependenciesReturns
+	fake.recordInvocation("GetRustDependencies", []interface{}{arg1, arg2})
+	fake.getRustDependenciesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeSpdxImplementation) GetRustDependenciesCallCount() int {
+	fake.getRustDependenciesMutex.RLock()
+	defer fake.getRustDependenciesMutex.RUnlock()
+	return len(fake.getRustDependenciesArgsForCall)
+}
+
+func (fake *FakeSpdxImplementation) GetRustDependenciesCalls(stub func(string, *spdx.Options) ([]*spdx.Package, error)) {
+	fake.getRustDependenciesMutex.Lock()
+	defer fake.getRustDependenciesMutex.Unlock()
+	fake.GetRustDependenciesStub = stub
+}
+
+func (fake *FakeSpdxImplementation) GetRustDependenciesArgsForCall(i int) (string, *spdx.Options) {
+	fake.getRustDependenciesMutex.RLock()
+	defer fake.getRustDependenciesMutex.RUnlock()
+	argsForCall := fake.getRustDependenciesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeSpdxImplementation) GetRustDependenciesReturns(result1 []*spdx.Package, result2 error) {
+	fake.getRustDependenciesMutex.Lock()
+	defer fake.getRustDependenciesMutex.Unlock()
+	fake.GetRustDependenciesStub = nil
+	fake.getRustDependenciesReturns = struct {
+		result1 []*spdx.Package
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSpdxImplementation) GetRustDependenciesReturnsOnCall(i int, result1 []*spdx.Package, result2 error) {
+	fake.getRustDependenciesMutex.Lock()
+	defer fake.getRustDependenciesMutex.Unlock()
+	fake.GetRustDependenciesStub = nil
+	if fake.getRustDependenciesReturnsOnCall == nil {
+		fake.getRustDependenciesReturnsOnCall = make(map[int]struct {
+			result1 []*spdx.Package
+			result2 error
+		})
+	}
+	fake.getRustDependenciesReturnsOnCall[i] = struct {
 		result1 []*spdx.Package
 		result2 error
 	}{result1, result2}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

I need to generate SBOMs for more than golang projects and this will let me do that :angel: 

See a bunch of work under https://github.com/cncf/automation to understand the motivations 

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

Yes, it adds flags to generate separate SBOM files if the repo is mixed-language or merge it down into a single one (default merged)


```release-note
add support to generate sbom data for python, nodejs, and rust 
```

cc @mfahlandt @puerco @mlieberman85