### PR TITLE
Sync OWNERS, OWNERS_ALIASES and SECURITY_CONTACTS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,3 +2,9 @@
 
 approvers:
   - sig-release-leads
+  - release-engineering-approvers
+reviewers:
+  - release-engineering-reviewers
+labels:
+  - sig/release
+  - area/release-eng

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,3 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
 aliases:
   sig-release-leads:
     - cpanato # SIG Technical Lead
@@ -6,3 +8,18 @@ aliases:
     - puerco # SIG Technical Lead
     - saschagrunert # SIG Chair
     - Verolop # SIG Technical Lead
+  release-engineering-approvers:
+    - cici37 # Release Manager
+    - cpanato # subproject owner / Release Manager
+    - jeremyrickard # subproject owner / Release Manager
+    - justaugustus # subproject owner / Release Manager
+    - palnabarun # Release Manager
+    - puerco # subproject owner / Release Manager
+    - saschagrunert # subproject owner / Release Manager
+    - xmudrii # Release Manager
+    - Verolop # subproject owner / Release Manager
+  release-engineering-reviewers:
+    - ameukam # Release Manager Associate
+    - jimangel # Release Manager Associate
+    - jrsapi # Release Manager Associate
+    - salaxander # Release Manager Associate

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -15,3 +15,4 @@ jeremyrickard
 justaugustus
 puerco
 saschagrunert
+Verolop


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Update OWNERS to use standard SIG Release / release-engineering aliases
- Sync OWNERS_ALIASES with canonical source (kubernetes/sig-release)
- Update SECURITY_CONTACTS with current SIG leads

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```