### PR TITLE
spdx: fix panic on malformed tag-value package tags

### DIFF
--- a/pkg/spdx/parser.go
+++ b/pkg/spdx/parser.go
@@ -546,19 +546,47 @@ func parseTagValue(file *os.File) (doc *Document, err error) {
 			}
 			// Tags for packages
 		case "FilesAnalyzed":
-			currentObject.(*Package).FilesAnalyzed = value == "true" //nolint: errcheck
+			pkg, ok := currentObject.(*Package)
+			if !ok {
+				return nil, fmt.Errorf("tag %s found outside of a package entry at line %d", tag, i)
+			}
+			pkg.FilesAnalyzed = value == "true"
 		case "PackageVersion":
-			currentObject.(*Package).Version = value //nolint: errcheck
+			pkg, ok := currentObject.(*Package)
+			if !ok {
+				return nil, fmt.Errorf("tag %s found outside of a package entry at line %d", tag, i)
+			}
+			pkg.Version = value
 		case "PackageLicenseDeclared":
-			currentObject.(*Package).LicenseDeclared = value //nolint: errcheck
+			pkg, ok := currentObject.(*Package)
+			if !ok {
+				return nil, fmt.Errorf("tag %s found outside of a package entry at line %d", tag, i)
+			}
+			pkg.LicenseDeclared = value
 		case "PackageVerificationCode":
-			currentObject.(*Package).VerificationCode = value //nolint: errcheck
+			pkg, ok := currentObject.(*Package)
+			if !ok {
+				return nil, fmt.Errorf("tag %s found outside of a package entry at line %d", tag, i)
+			}
+			pkg.VerificationCode = value
 		case "PackageComment":
-			currentObject.(*Package).Comment = value //nolint: errcheck
+			pkg, ok := currentObject.(*Package)
+			if !ok {
+				return nil, fmt.Errorf("tag %s found outside of a package entry at line %d", tag, i)
+			}
+			pkg.Comment = value
 		case "PackageFileName":
-			currentObject.(*Package).FileName = value //nolint: errcheck
+			pkg, ok := currentObject.(*Package)
+			if !ok {
+				return nil, fmt.Errorf("tag %s found outside of a package entry at line %d", tag, i)
+			}
+			pkg.FileName = value
 		case "PackageHomePage":
-			currentObject.(*Package).HomePage = value //nolint: errcheck
+			pkg, ok := currentObject.(*Package)
+			if !ok {
+				return nil, fmt.Errorf("tag %s found outside of a package entry at line %d", tag, i)
+			}
+			pkg.HomePage = value
 		case "PrimaryPackagePurpose":
 			purpose := ""
 			for _, pp := range PackagePurposes {

--- a/pkg/spdx/parser_unit_test.go
+++ b/pkg/spdx/parser_unit_test.go
@@ -23,6 +23,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestParseTagValueMalformedPackageTags checks that package-only tags
+// (FilesAnalyzed, PackageVersion, etc) return an error instead of panicking
+// when they appear before a PackageName tag has set up a *Package object.
+func TestParseTagValueMalformedPackageTags(t *testing.T) {
+	for _, tag := range []string{
+		"FilesAnalyzed: true",
+		"PackageVersion: 1.0.0",
+		"PackageLicenseDeclared: MIT",
+		"PackageVerificationCode: abc123",
+		"PackageComment: a comment",
+		"PackageFileName: file.tar.gz",
+		"PackageHomePage: https://example.com",
+	} {
+		content := "SPDXVersion: SPDX-2.3\nDataLicense: CC0-1.0\n" + tag + "\n"
+
+		f, err := os.CreateTemp(t.TempDir(), "malformed-*.spdx")
+		require.NoError(t, err)
+
+		_, err = f.WriteString(content)
+		require.NoError(t, err)
+
+		_, err = f.Seek(0, 0)
+		require.NoError(t, err)
+
+		_, err = parseTagValue(f)
+		require.Error(t, err, "expected an error for tag %q, got none", tag)
+
+		require.NoError(t, f.Close())
+	}
+}
+
 func TestDetectSBOMEncoding(t *testing.T) {
 	for _, tc := range []struct {
 		fragment         string


### PR DESCRIPTION
/kind bug

#### What type of PR is this?

Bug fix in the tag-value SPDX parser.

#### What this PR does / why we need it:

`parseTagValue` in `pkg/spdx/parser.go` reads tag-value SPDX documents and, for several package-only tags (`FilesAnalyzed`, `PackageVersion`, `PackageLicenseDeclared`, `PackageVerificationCode`, `PackageComment`, `PackageFileName`, `PackageHomePage`), casts `currentObject` straight to `*Package` with `currentObject.(*Package)` and a `//nolint: errcheck` to silence the linter. If one of those tags appears before a `PackageName` tag has run (or while `currentObject` is still a `*File` from a preceding `FileName` tag), the assertion has nothing to convert and panics instead of returning an error. Since this function parses external input (any tag-value SBOM handed to `bom` for validation/conversion), a malformed or hand-crafted document can crash the process.

Switched each of those cases to the comma-ok form so a misplaced tag now returns `fmt.Errorf(...)` naming the tag and line number instead of panicking.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Added `TestParseTagValueMalformedPackageTags` in `pkg/spdx/parser_unit_test.go` which feeds `parseTagValue` a minimal doc containing only one of the affected tags with no preceding `PackageName`. Before this change it panics (`interface conversion: spdx.Object is nil, not *spdx.Package`); after, it returns a clean error. Ran the full `pkg/spdx` suite locally, all green.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a crash when parsing a malformed tag-value SPDX document where a package-scoped tag appears outside of a package entry; the parser now returns an error instead of panicking.
```
