### PR TITLE
Bump golangci-lint to v2.13.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ linters:
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan
@@ -164,6 +164,9 @@ linters:
           - gocritic
           - golint
         path: fake_.*\.go
+      - linters:
+          - goconst
+        path: _test\.go
     paths:
       - third_party$
       - builtin$

--- a/magefile.go
+++ b/magefile.go
@@ -87,7 +87,7 @@ func Verify() error {
 	}
 
 	fmt.Println("Running golangci-lint...")
-	if err := mage.RunGolangCILint("", true); err != nil {
+	if err := mage.RunGolangCILint("v2.13.1", true); err != nil {
 		return err
 	}
 

--- a/pkg/spdx/gomod.go
+++ b/pkg/spdx/gomod.go
@@ -227,7 +227,7 @@ func (pkg *GoPackage) ToSPDXPackage() (*Package, error) {
 	if packageurl := pkg.PackageURL(); packageurl != "" {
 		spdxPackage.ExternalRefs = append(spdxPackage.ExternalRefs, ExternalRef{
 			Category: CatPackageManager,
-			Type:     "purl",
+			Type:     ExtRefTypePurl,
 			Locator:  packageurl,
 		})
 	}

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -820,7 +820,7 @@ func (di *spdxDefaultImplementation) ImageRefToPackage(ref string, opts *Options
 	if packageurl != "" {
 		pkg.ExternalRefs = append(pkg.ExternalRefs, ExternalRef{
 			Category: CatPackageManager,
-			Type:     "purl",
+			Type:     ExtRefTypePurl,
 			Locator:  packageurl,
 		})
 	}
@@ -858,7 +858,7 @@ func (di *spdxDefaultImplementation) referenceInfoToPackage(opts *Options, img *
 	if packageurl != "" {
 		subpkg.ExternalRefs = append(subpkg.ExternalRefs, ExternalRef{
 			Category: CatPackageManager,
-			Type:     "purl",
+			Type:     ExtRefTypePurl,
 			Locator:  packageurl,
 		})
 	}
@@ -996,7 +996,7 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 				if (*osPackageData)[i].PackageURL() != "" {
 					ospk.ExternalRefs = append(ospk.ExternalRefs, ExternalRef{
 						Category: CatPackageManager,
-						Type:     "purl",
+						Type:     ExtRefTypePurl,
 						Locator:  (*osPackageData)[i].PackageURL(),
 					})
 				}

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -123,8 +123,8 @@ var PackagePurposes = []string{
 
 var ExternalRefCategories = map[string][]string{
 	"SECURITY":        {"cpe22Type", "cpe23Type", "advisory", "fix", "url", "swid"},
-	"PACKAGE_MANAGER": {"maven-central", "npm", "nuget", "bower", "purl"},
-	"PACKAGE-MANAGER": {"maven-central", "npm", "nuget", "bower", "purl"},
+	"PACKAGE_MANAGER": {"maven-central", "npm", "nuget", "bower", ExtRefTypePurl},
+	"PACKAGE-MANAGER": {"maven-central", "npm", "nuget", "bower", ExtRefTypePurl},
 	"PERSISTENT-ID":   {"swh", "gitoid"},
 	"PERSISTENT_ID":   {"swh", "gitoid"},
 	"OTHER":           {},
@@ -517,7 +517,7 @@ func (p *Package) Purl() *purl.PackageURL {
 	}
 	purlString := ""
 	for _, er := range p.ExternalRefs {
-		if (er.Category == "PACKAGE-MANAGER" || er.Category == "PACKAGE_MANAGER") && er.Type == "purl" {
+		if (er.Category == "PACKAGE-MANAGER" || er.Category == "PACKAGE_MANAGER") && er.Type == ExtRefTypePurl {
 			purlString = er.Locator
 		}
 	}

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -49,6 +49,7 @@ const (
 	entOrganization = "Organization"
 
 	CatPackageManager = "PACKAGE-MANAGER"
+	ExtRefTypePurl    = "purl"
 
 	termBanner = `ICAgICAgICAgICAgICAgXyAgICAgIAogX19fIF8gX18gICBfX3wgfF8gIF9fCi8gX198ICdfIFwg
 LyBfYCBcIFwvIC8KXF9fIFwgfF8pIHwgKF98IHw+ICA8IAp8X19fLyAuX18vIFxfXyxfL18vXF9c


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind flake

#### What this PR does / why we need it:

The golangci-lint jobs have been failing on this repo, the jobs are running out of memory (see https://github.com/kubernetes-sigs/bom/pull/686 and https://github.com/kubernetes-sigs/bom/pull/684). Before attempting to increase the job's ram allocation, this PR tries bumping golangci lint to v2.13  to see if this helps.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
